### PR TITLE
feat(rulesets): consolidate templates and add OSS bypass ruleset

### DIFF
--- a/config/repository/test-rulesets.yml
+++ b/config/repository/test-rulesets.yml
@@ -1,0 +1,32 @@
+# Test repository configuration to verify template functionality
+# These repositories test both template usage and direct ruleset references
+
+test-strict-main:
+  description: "Test repository using strict-main template"
+  visibility: public
+  groups: []
+  rulesets:
+    - template: strict-main
+
+test-relaxed-devel:
+  description: "Test repository using relaxed-devel template"
+  visibility: public
+  groups: []
+  rulesets:
+    - template: relaxed-devel
+
+test-oss-bypass:
+  description: "Test repository using oss-main-bypass ruleset"
+  visibility: public
+  groups: []
+  rulesets:
+    - oss-main-bypass
+
+test-mixed:
+  description: "Test repository mixing templates and direct rulesets"
+  visibility: public
+  groups: []
+  rulesets:
+    - template: strict-main
+    - oss-main-bypass
+    - tag-protection

--- a/config/ruleset/default-rulesets.yml
+++ b/config/ruleset/default-rulesets.yml
@@ -1,5 +1,19 @@
-# Default Repository Rulesets
+# Default Repository Rulesets and Templates
 # Define reusable rulesets that can be applied to config groups or individual repositories
+#
+# Rulesets can be:
+# 1. Applied directly by reference (e.g., rulesets: [oss-main-protection])
+# 2. Used as templates with the 'template' key (e.g., template: strict-main)
+#
+# When using templates in repositories.yml or groups.yml:
+#   rulesets:
+#     - template: strict-main
+#     - template: relaxed-devel
+#       # Override template settings (optional)
+#       rules:
+#         - type: pull_request
+#           parameters:
+#             required_approving_review_count: 2
 #
 # Supported rule types:
 # - deletion: Prevent branch/tag deletion
@@ -13,7 +27,59 @@
 # - commit_message_pattern: Enforce commit message patterns
 # - branch_name_pattern: Enforce branch naming patterns
 
+# ============================================================================
+# TEMPLATE RULESETS
+# Pre-built configurations that can be referenced by name in repository configs
+# ============================================================================
+
+# Strict main branch protection
+# Enforces 2 required approvals, code owner review, and linear history
+strict-main:
+  target: branch
+  enforcement: active
+  conditions:
+    ref_name:
+      include:
+        - "~DEFAULT_BRANCH"
+      exclude: []
+  rules:
+    - type: deletion
+    - type: non_fast_forward
+    - type: required_linear_history
+    - type: pull_request
+      parameters:
+        required_approving_review_count: 2
+        dismiss_stale_reviews_on_push: true
+        require_code_owner_review: true
+        require_last_push_approval: false
+
+# Relaxed devel branch protection
+# Enforces 1 required approval for devel branch
+relaxed-devel:
+  target: branch
+  enforcement: active
+  conditions:
+    ref_name:
+      include:
+        - "refs/heads/devel"
+      exclude: []
+  rules:
+    - type: deletion
+    - type: non_fast_forward
+    - type: pull_request
+      parameters:
+        required_approving_review_count: 1
+        dismiss_stale_reviews_on_push: true
+        require_code_owner_review: false
+        require_last_push_approval: false
+
+# ============================================================================
+# DEFAULT RULESETS
+# Standard rulesets for common repository configurations
+# ============================================================================
+
 # Main branch protection for open source repositories
+# Basic protection requiring 1 approval and linear history
 oss-main-protection:
   target: branch
   enforcement: active
@@ -26,6 +92,34 @@ oss-main-protection:
     - type: deletion
     - type: non_fast_forward
     - type: required_linear_history
+    - type: pull_request
+      parameters:
+        required_approving_review_count: 1
+        dismiss_stale_reviews_on_push: true
+        require_code_owner_review: false
+        require_last_push_approval: false
+
+# Main branch protection for OSS with maintainer bypass
+# Allows repository maintainers and admins to bypass branch protection
+# Suitable for open source projects where maintainers need flexibility
+oss-main-bypass:
+  target: branch
+  enforcement: active
+  bypass_actors:
+    - actor_type: RepositoryRole
+      actor_id: 2  # Maintain role
+      bypass_mode: always
+    - actor_type: RepositoryRole
+      actor_id: 5  # Admin role
+      bypass_mode: always
+  conditions:
+    ref_name:
+      include:
+        - "~DEFAULT_BRANCH"
+      exclude: []
+  rules:
+    - type: deletion
+    - type: non_fast_forward
     - type: pull_request
       parameters:
         required_approving_review_count: 1
@@ -48,28 +142,8 @@ internal-main-protection:
     - type: non_fast_forward
     - type: required_linear_history
 
-# Release branch protection (example)
-release-branch-protection:
-  target: branch
-  enforcement: active
-  conditions:
-    ref_name:
-      include:
-        - "refs/heads/release/*"
-        - "refs/heads/v*"
-      exclude: []
-  rules:
-    - type: deletion
-    - type: non_fast_forward
-    - type: required_linear_history
-    - type: pull_request
-      parameters:
-        required_approving_review_count: 2
-        dismiss_stale_reviews_on_push: true
-        require_code_owner_review: true
-        require_last_push_approval: true
-
-# Tag protection (example)
+# Tag protection for version tags
+# Prevents deletion and updates to version tags (v*)
 tag-protection:
   target: tag
   enforcement: active


### PR DESCRIPTION
Closes #2

This PR consolidates ruleset configuration management and adds a new OSS-friendly bypass ruleset:

- **Consolidated configuration**: Merged `templates.yml` into `default-rulesets.yml` for single source of truth
- **New OSS bypass ruleset**: Added `oss-main-bypass` with maintainer/admin bypass actors for flexible OSS workflows
- **Improved naming**: Renamed `relaxed-dev` → `relaxed-devel` (targets `devel` branch only)
- **Cleanup**: Removed unused `release-branch-protection` ruleset
- **Fixed validation**: Updated Terraform to handle mixed template/direct ruleset references
- **Test configuration**: Added test repositories to verify functionality

## Changes

### Configuration Files
- Merged `config/ruleset/templates.yml` → `config/ruleset/default-rulesets.yml`
- Added new `oss-main-bypass` ruleset with bypass actors (Maintain & Admin roles)
- Created `config/repository/test-rulesets.yml` with 4 test repositories

### Terraform Updates
- Updated `terraform/yaml-config.tf` to load templates from consolidated file
- Fixed validation logic (line 216) to handle mixed template/direct references by removing premature `distinct()` call

### Documentation
- Updated `docs/CONFIGURATION.md` with complete ruleset documentation
- Added examples for all default templates and rulesets
- Fixed markdown formatting (line length, list spacing)

## Available Rulesets

### Templates (use with `template:` key)
- `strict-main` - 2 required reviews, code owner approval, linear history
- `relaxed-devel` - 1 required review, targets devel branch

### Direct Rulesets
- `oss-main-protection` - Basic OSS protection, no bypass
- `oss-main-bypass` - OSS protection with maintainer/admin bypass ✨ NEW
- `internal-main-protection` - Internal repos, no PR requirements
- `tag-protection` - Protects version tags (v*)

## Testing

✅ Terraform validate passes  
✅ Terraform plan shows 10 resources (4 repos, 6 rulesets)  
✅ Template-based rulesets use `tpl-` prefix  
✅ Direct rulesets use original names  
✅ All pre-commit hooks pass
