### PR TITLE
feat: add webhook configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Manage your GitHub organization's repositories as code using Terraform and YAML 
 - **Configuration groups** - Share settings across multiple repositories (DRY)
 - **Repository rulesets** - Enforce branch protection and policies
 - **GitHub Actions permissions** - Control which actions can run and workflow permissions
+- **Webhook management** - Configure CI/CD and notification webhooks as code
 - **Subscription-aware** - Gracefully handles GitHub Free tier limitations
 - **Onboarding script** - Easily import existing repositories
 
@@ -66,6 +67,8 @@ docs-site:
   description: "Documentation website"
   groups: ["base", "oss"]
   homepage_url: "https://docs.example.com"
+  webhooks:
+    - slack-notify        # Reference webhook from config/webhook/
 ```
 
 ## 📚 Documentation

--- a/config/group/default-groups.yml
+++ b/config/group/default-groups.yml
@@ -31,6 +31,10 @@ oss:
     - open-source
   rulesets:
     - oss-main-protection
+  # Webhooks: reference by name from config/webhook/ or define inline
+  # webhooks:
+  #   - slack-notify           # Reference by name
+  #   - security-scanner       # Reference by name
 
 # Internal - Private repositories
 # Use this group for internal/private projects
@@ -68,3 +72,7 @@ internal:
 #       patterns_allowed:             # Additional allowed patterns
 #         - "actions/*"               # Official GitHub actions
 #         - "your-org/*"              # Your organization's actions
+  # Webhooks: reference by name from config/webhook/ or define inline
+  # webhooks:
+  #   - jenkins-ci             # Reference by name
+  #   - slack-notify           # Reference by name

--- a/config/repository/example-repositories.yml
+++ b/config/repository/example-repositories.yml
@@ -33,6 +33,12 @@
 #   has_discussions: true        # Override: enable discussions
 #   topics:
 #     - custom
+#   # Webhooks: reference by name or define inline
+#   webhooks:
+#     - slack-notify             # Reference by name from config/webhook/
+#     - name: custom-webhook     # Inline definition
+#       url: https://custom.example.com/webhook
+#       events: [push, release]
 
 # Empty document marker (required for valid YAML when all content is commented)
 ---

--- a/config/webhook/examples.yml
+++ b/config/webhook/examples.yml
@@ -1,0 +1,55 @@
+# Webhook Definitions
+# Define webhooks here and reference them by name in groups or repositories
+# Each webhook is identified by its key (name) and can be reused across repos
+#
+# Schema:
+#   webhook-name:
+#     url: https://example.com/webhook     # Required: Webhook endpoint URL
+#     content_type: json                    # Optional: json (default) or form
+#     secret: env:WEBHOOK_SECRET_VAR        # Optional: Secret from webhook_secrets variable # pragma: allowlist secret
+#     events: [push, pull_request]          # Required: GitHub events to trigger webhook
+#     active: true                          # Optional: Enable webhook (default: true)
+#     insecure_ssl: false                   # Optional: Skip SSL verification (default: false)
+#
+# To use a webhook secret: # pragma: allowlist secret
+#   1. Define secret: env:MY_SECRET_VAR in your webhook # pragma: allowlist secret
+#   2. Pass the secret value via Terraform: # pragma: allowlist secret
+#      terraform apply -var='webhook_secrets={"MY_SECRET_VAR":"actual-secret-value"}' # pragma: allowlist secret
+#      Or use environment variable: export TF_VAR_webhook_secrets='{"MY_SECRET_VAR":"actual-secret-value"}' # pragma: allowlist secret
+#
+# Example webhook definitions (uncomment to use):
+
+# jenkins-ci:
+#   url: https://jenkins.example.com/github-webhook/
+#   content_type: json
+#   secret: env:JENKINS_WEBHOOK_SECRET # pragma: allowlist secret
+#   events:
+#     - push
+#     - pull_request
+#   active: true
+
+# slack-notify:
+#   url: https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+#   content_type: json
+#   events:
+#     - push
+#     - release
+#     - pull_request
+#   active: true
+
+# discord-notify:
+#   url: https://discord.com/api/webhooks/YOUR/WEBHOOK/URL
+#   content_type: json
+#   events:
+#     - push
+#     - release
+#   active: true
+
+# security-scanner:
+#   url: https://security.example.com/scan
+#   content_type: json
+#   secret: env:SECURITY_WEBHOOK_SECRET # pragma: allowlist secret
+#   events:
+#     - push
+#     - pull_request
+#   active: true

--- a/openspec/changes/add-webhook-configuration/tasks.md
+++ b/openspec/changes/add-webhook-configuration/tasks.md
@@ -2,47 +2,47 @@
 
 ## 1. Schema and Variables
 
-- [ ] 1.1 Add `webhooks` variable to `terraform/modules/repository/variables.tf`
-- [ ] 1.2 Define webhook object type with url, content_type, secret, events, active, insecure_ssl fields
+- [x] 1.1 Add `webhooks` variable to `terraform/modules/repository/variables.tf`
+- [x] 1.2 Define webhook object type with url, content_type, secret, events, active, insecure_ssl fields
 
 ## 2. Repository Module Implementation
 
-- [ ] 2.1 Add `github_repository_webhook` resource to `terraform/modules/repository/main.tf`
-- [ ] 2.2 Implement environment variable lookup for webhook secrets
-- [ ] 2.3 Add webhook outputs to `terraform/modules/repository/outputs.tf`
+- [x] 2.1 Add `github_repository_webhook` resource to `terraform/modules/repository/main.tf`
+- [x] 2.2 Implement environment variable lookup for webhook secrets
+- [x] 2.3 Add webhook outputs to `terraform/modules/repository/outputs.tf`
 
 ## 3. Webhook Definitions Loading
 
-- [ ] 3.1 Add logic to load webhook definitions from `config/webhook/` directory
-- [ ] 3.2 Merge webhook definition files alphabetically
-- [ ] 3.3 Handle missing `config/webhook/` directory gracefully (empty map)
+- [x] 3.1 Add logic to load webhook definitions from `config/webhook/` directory
+- [x] 3.2 Merge webhook definition files alphabetically
+- [x] 3.3 Handle missing `config/webhook/` directory gracefully (empty map)
 
 ## 4. Configuration Merging
 
-- [ ] 4.1 Add webhook reference resolution logic to `terraform/yaml-config.tf`
-- [ ] 4.2 Support both reference-by-name and inline webhook definitions
-- [ ] 4.3 Implement group webhook merging (later groups override by name)
-- [ ] 4.4 Implement repository webhook merging (repo overrides group by name)
-- [ ] 4.5 Add validation for undefined webhook references
-- [ ] 4.6 Pass merged webhooks to repository module
+- [x] 4.1 Add webhook reference resolution logic to `terraform/yaml-config.tf`
+- [x] 4.2 Support both reference-by-name and inline webhook definitions
+- [x] 4.3 Implement group webhook merging (later groups override by name)
+- [x] 4.4 Implement repository webhook merging (repo overrides group by name)
+- [x] 4.5 Add validation for undefined webhook references
+- [x] 4.6 Pass merged webhooks to repository module
 
 ## 5. Example Configuration
 
-- [ ] 5.1 Create `config/webhook/` directory with example files (commented out)
-- [ ] 5.2 Add example webhook references to group configuration (commented out)
-- [ ] 5.3 Add example webhook references to repository configuration (commented out)
+- [x] 5.1 Create `config/webhook/` directory with example files (commented out)
+- [x] 5.2 Add example webhook references to group configuration (commented out)
+- [x] 5.3 Add example webhook references to repository configuration (commented out)
 
 ## 6. Documentation
 
-- [ ] 6.1 Update README with webhook configuration examples
-- [ ] 6.2 Document supported GitHub events
-- [ ] 6.3 Document secret handling pattern (`env:VAR_NAME`)
-- [ ] 6.4 Document webhook definition vs reference pattern
+- [x] 6.1 Update README with webhook configuration examples
+- [x] 6.2 Document supported GitHub events
+- [x] 6.3 Document secret handling pattern (`env:VAR_NAME`)
+- [x] 6.4 Document webhook definition vs reference pattern
 
 ## 7. Validation
 
-- [ ] 7.1 Run `terraform validate` to verify syntax
-- [ ] 7.2 Run `terraform plan` to verify resource creation
-- [ ] 7.3 Test webhook inheritance from groups
-- [ ] 7.4 Test repository-level webhook overrides
-- [ ] 7.5 Test undefined webhook reference error handling
+- [x] 7.1 Run `terraform validate` to verify syntax
+- [x] 7.2 Run `terraform plan` to verify resource creation
+- [x] 7.3 Test webhook inheritance from groups
+- [x] 7.4 Test repository-level webhook overrides
+- [x] 7.5 Test undefined webhook reference error handling

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,6 +62,9 @@ module "repositories" {
 
   # Apply Actions permissions configuration
   actions = each.value.actions
+
+  # Apply webhooks from groups and repo-specific definitions
+  webhooks = each.value.webhooks
 }
 
 # Organization-level Actions permissions

--- a/terraform/modules/repository/main.tf
+++ b/terraform/modules/repository/main.tf
@@ -209,3 +209,21 @@ resource "github_actions_repository_permissions" "this" {
     }
   }
 }
+
+# Manage repository webhooks
+# Note: Secrets are resolved at the yaml-config layer before being passed to this module
+resource "github_repository_webhook" "this" {
+  for_each = var.webhooks
+
+  repository = github_repository.this.name
+
+  configuration {
+    url          = each.value.url
+    content_type = each.value.content_type
+    secret       = each.value.secret
+    insecure_ssl = each.value.insecure_ssl
+  }
+
+  events = each.value.events
+  active = each.value.active
+}

--- a/terraform/modules/repository/outputs.tf
+++ b/terraform/modules/repository/outputs.tf
@@ -39,3 +39,10 @@ output "repo_id" {
   description = "Repository ID"
   value       = github_repository.this.repo_id
 }
+
+output "webhooks" {
+  description = "Map of webhook names to their URLs"
+  value = {
+    for name, webhook in github_repository_webhook.this : name => webhook.url
+  }
+}

--- a/terraform/modules/repository/variables.tf
+++ b/terraform/modules/repository/variables.tf
@@ -198,3 +198,15 @@ variable "actions" {
     error_message = "allowed_actions must be 'all', 'local_only', or 'selected'."
   }
 }
+variable "webhooks" {
+  description = "Map of repository webhooks to create"
+  type = map(object({
+    url          = string
+    content_type = optional(string, "json")
+    secret       = optional(string)
+    events       = list(string)
+    active       = optional(bool, true)
+    insecure_ssl = optional(bool, false)
+  }))
+  default = {}
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,2 +1,9 @@
 # Variables for the root module
 # Currently all configuration is read from YAML files in config/
+
+variable "webhook_secrets" {
+  description = "Map of webhook secret names to their values. Keys should match the VAR_NAME in env:VAR_NAME patterns used in webhook configurations."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}


### PR DESCRIPTION
Adds comprehensive webhook configuration support to the GitHub organization template, enabling declarative management of repository webhooks through YAML configuration files.

Closes #4

## Features

- **Centralized webhook definitions** in `config/webhook/` directory
- **Group-level webhooks** that apply to all repositories in a group
- **Repository-specific webhooks** with override capability
- **Secure secret handling** via `webhook_secrets` Terraform variable
- **Flexible definition styles**: reference by name or inline configuration
- **Merge-by-name semantics**: webhooks with same name are merged/overridden

## Implementation Details

### New Files
- `config/webhook/examples.yml` - Example webhook definitions (commented)
- Updated `config/group/default-groups.yml` - Group webhook examples
- Updated `config/repository/example-repositories.yml` - Repository webhook examples

### Terraform Changes
- `terraform/modules/repository/`: Added webhook resource, variables, and outputs
- `terraform/yaml-config.tf`: Added webhook loading and merging logic (~100 lines)
- `terraform/variables.tf`: Added `webhook_secrets` sensitive variable
- `terraform/main.tf`: Updated to pass webhooks to repository module

### Documentation
- `docs/CONFIGURATION.md`: Comprehensive webhook configuration guide
- `README.md`: Added webhook feature to features list

## Usage Example

### Define Webhooks
```yaml
# config/webhook/ci-cd.yml
webhooks:
  jenkins-ci:
    url: https://jenkins.example.com/github-webhook/
    content_type: json
    events: ["push", "pull_request"]
    active: true
    secret: env:JENKINS_WEBHOOK_SECRET
```

### Apply to Group
```yaml
# config/group/oss.yml
group_name: oss
webhooks:
  - jenkins-ci  # Reference by name
```

### Override in Repository
```yaml
# config/repository/my-repo.yml
name: my-repo
group: oss
webhooks:
  - name: jenkins-ci
    url: https://jenkins-special.example.com/webhook/  # Override URL
```

### Set Secrets
```bash
export TF_VAR_webhook_secrets='{"JENKINS_WEBHOOK_SECRET":"secret-value"}'
terraform apply
```

## Secret Handling

Secrets use the `env:VAR_NAME` pattern and are resolved via the `webhook_secrets` Terraform variable (map of string values). This keeps secrets out of YAML files while maintaining security through Terraform's sensitive variable handling.

## Validation

- ✅ Terraform validation passing
- ✅ Pre-commit hooks passing
- ✅ All 26 implementation tasks completed
- ✅ Examples provided for common use cases (Jenkins, Slack, Discord, security scanners)
- ✅ Backward compatible - webhook directory is optional

## Migration Notes

Works seamlessly with the new directory-based configuration structure. No breaking changes to existing configurations.

## Related

Implements all requirements from issue #4 including:
- Webhook configuration schema
- Repository module webhook support
- Secure secret handling
- Group-level webhook inheritance
- Documentation and examples for common integrations