### PR TITLE
feat(team): add GitHub Teams management

### DIFF
--- a/examples/consumer/config/team/engineering.yml
+++ b/examples/consumer/config/team/engineering.yml
@@ -4,6 +4,11 @@
 # Child teams are nested under the parent's `teams:` key (up to 3 levels deep).
 #
 # Remove or replace with your real team definitions before applying.
+#
+# WARNING: Renaming a team slug (the YAML key) is DESTRUCTIVE. Terraform will
+# destroy the old team and create a new one, losing all repository assignments,
+# nested team relationships managed outside this module, and audit history.
+# To rename a team, use `terraform state mv` before changing the key.
 
 engineering:
   description: "Engineering organisation"

--- a/examples/consumer/config/team/engineering.yml
+++ b/examples/consumer/config/team/engineering.yml
@@ -1,0 +1,38 @@
+# Example team configuration.
+#
+# Teams are defined at the top level by their GitHub slug.
+# Child teams are nested under the parent's `teams:` key (up to 3 levels deep).
+#
+# Remove or replace with your real team definitions before applying.
+
+engineering:
+  description: "Engineering organisation"
+  privacy: closed
+  maintainers:
+    - eng-lead
+  members:
+    - dev1
+    - dev2
+  review_request_delegation:
+    enabled: true
+    algorithm: round_robin
+    member_count: 2
+    notify: true
+  teams:
+    platform-team:
+      description: "Platform engineering"
+      privacy: closed
+      maintainers:
+        - platform-lead
+      members:
+        - platform-dev1
+      teams:
+        platform-sre:
+          description: "Site reliability engineering"
+          members:
+            - sre1
+    frontend-team:
+      description: "Frontend engineering"
+      members:
+        - fe-dev1
+        - fe-dev2

--- a/main.tf
+++ b/main.tf
@@ -99,3 +99,51 @@ resource "github_actions_organization_workflow_permissions" "this" {
   # Secure default: false
   can_approve_pull_request_reviews = try(local.org_actions_config.can_approve_pull_request_reviews, false)
 }
+
+# Manage GitHub Teams - Tier 0 (root teams, no parent)
+# Only created for organizations (teams are not available for personal accounts)
+module "teams_root" {
+  source = "./modules/team"
+
+  for_each = local.is_organization ? local.tier_0_teams : {}
+
+  name        = each.value.name
+  description = each.value.description
+  privacy     = each.value.privacy
+  members     = each.value.members
+  maintainers = each.value.maintainers
+
+  review_request_delegation = each.value.review_request_delegation
+}
+
+# Manage GitHub Teams - Tier 1 (children of root teams)
+module "teams_level_1" {
+  source = "./modules/team"
+
+  for_each = local.is_organization ? local.tier_1_teams : {}
+
+  name           = each.value.name
+  description    = each.value.description
+  privacy        = each.value.privacy
+  parent_team_id = module.teams_root[each.value.parent_slug].team_id
+  members        = each.value.members
+  maintainers    = each.value.maintainers
+
+  review_request_delegation = each.value.review_request_delegation
+}
+
+# Manage GitHub Teams - Tier 2 (grandchildren, max depth)
+module "teams_level_2" {
+  source = "./modules/team"
+
+  for_each = local.is_organization ? local.tier_2_teams : {}
+
+  name           = each.value.name
+  description    = each.value.description
+  privacy        = each.value.privacy
+  parent_team_id = module.teams_level_1[each.value.parent_slug].team_id
+  members        = each.value.members
+  maintainers    = each.value.maintainers
+
+  review_request_delegation = each.value.review_request_delegation
+}

--- a/modules/team/main.tf
+++ b/modules/team/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+resource "github_team" "this" {
+  name           = var.name
+  description    = var.description
+  privacy        = var.privacy
+  parent_team_id = var.parent_team_id
+}
+
+# Manage team members
+resource "github_team_membership" "members" {
+  for_each = toset(var.members)
+
+  team_id  = github_team.this.id
+  username = each.value
+  role     = "member"
+}
+
+# Manage team maintainers
+resource "github_team_membership" "maintainers" {
+  for_each = toset(var.maintainers)
+
+  team_id  = github_team.this.id
+  username = each.value
+  role     = "maintainer"
+}
+
+# Manage PR review request delegation settings
+# Only created when review_request_delegation is provided
+resource "github_team_settings" "this" {
+  count = var.review_request_delegation != null ? 1 : 0
+
+  team_id = github_team.this.id
+
+  review_request_delegation {
+    algorithm    = var.review_request_delegation.algorithm
+    member_count = var.review_request_delegation.member_count
+    notify       = var.review_request_delegation.notify
+  }
+}

--- a/modules/team/main.tf
+++ b/modules/team/main.tf
@@ -35,9 +35,11 @@ resource "github_team_membership" "maintainers" {
 }
 
 # Manage PR review request delegation settings
-# Only created when review_request_delegation is provided
+# Only created when review_request_delegation is provided AND enabled is true
+# Note: the GitHub provider does not support a "disabled" delegation state via HCL;
+# setting enabled = false removes the resource, which is the closest approximation.
 resource "github_team_settings" "this" {
-  count = var.review_request_delegation != null ? 1 : 0
+  count = (var.review_request_delegation != null && var.review_request_delegation.enabled) ? 1 : 0
 
   team_id = github_team.this.id
 

--- a/modules/team/main.tf
+++ b/modules/team/main.tf
@@ -39,13 +39,17 @@ resource "github_team_membership" "maintainers" {
 # Note: the GitHub provider does not support a "disabled" delegation state via HCL;
 # setting enabled = false removes the resource, which is the closest approximation.
 resource "github_team_settings" "this" {
-  count = (var.review_request_delegation != null && var.review_request_delegation.enabled) ? 1 : 0
+  # coalesce guards against an explicit `enabled: null` in YAML, which bypasses
+  # the optional() default and would otherwise cause a type error in the condition.
+  count = (var.review_request_delegation != null && coalesce(var.review_request_delegation.enabled, true)) ? 1 : 0
 
   team_id = github_team.this.id
 
   review_request_delegation {
-    algorithm    = var.review_request_delegation.algorithm
-    member_count = var.review_request_delegation.member_count
-    notify       = var.review_request_delegation.notify
+    # coalesce(try(...)) guards against fields explicitly set to null in YAML,
+    # which bypasses optional() defaults and would fail at plan/apply time.
+    algorithm    = coalesce(try(var.review_request_delegation.algorithm, null), "round_robin")
+    member_count = coalesce(try(var.review_request_delegation.member_count, null), 1)
+    notify       = coalesce(try(var.review_request_delegation.notify, null), true)
   }
 }

--- a/modules/team/outputs.tf
+++ b/modules/team/outputs.tf
@@ -1,0 +1,9 @@
+output "team_id" {
+  description = "The ID of the team (used as parent_team_id by child teams)"
+  value       = github_team.this.id
+}
+
+output "team_slug" {
+  description = "The slug of the team"
+  value       = github_team.this.slug
+}

--- a/modules/team/variables.tf
+++ b/modules/team/variables.tf
@@ -51,4 +51,9 @@ variable "review_request_delegation" {
     condition     = var.review_request_delegation == null || contains(["round_robin", "load_balance"], coalesce(var.review_request_delegation.algorithm, "round_robin"))
     error_message = "Algorithm must be 'round_robin' or 'load_balance'."
   }
+
+  validation {
+    condition     = var.review_request_delegation == null || coalesce(var.review_request_delegation.member_count, 1) > 0
+    error_message = "member_count must be greater than 0."
+  }
 }

--- a/modules/team/variables.tf
+++ b/modules/team/variables.tf
@@ -40,7 +40,7 @@ variable "maintainers" {
 variable "review_request_delegation" {
   description = "PR review request delegation settings"
   type = object({
-    enabled      = bool
+    enabled      = optional(bool, true)
     algorithm    = optional(string, "round_robin")
     member_count = optional(number, 1)
     notify       = optional(bool, true)

--- a/modules/team/variables.tf
+++ b/modules/team/variables.tf
@@ -1,0 +1,54 @@
+variable "name" {
+  description = "Team name (used as the team slug)"
+  type        = string
+}
+
+variable "description" {
+  description = "Team description"
+  type        = string
+}
+
+variable "privacy" {
+  description = "Team privacy level: closed (visible to org) or secret (only visible to members)"
+  type        = string
+  default     = "closed"
+
+  validation {
+    condition     = contains(["closed", "secret"], var.privacy)
+    error_message = "Privacy must be 'closed' or 'secret'."
+  }
+}
+
+variable "parent_team_id" {
+  description = "ID of the parent team (null for root teams)"
+  type        = string
+  default     = null
+}
+
+variable "members" {
+  description = "List of GitHub usernames to add as team members"
+  type        = list(string)
+  default     = []
+}
+
+variable "maintainers" {
+  description = "List of GitHub usernames to add as team maintainers"
+  type        = list(string)
+  default     = []
+}
+
+variable "review_request_delegation" {
+  description = "PR review request delegation settings"
+  type = object({
+    enabled      = bool
+    algorithm    = optional(string, "round_robin")
+    member_count = optional(number, 1)
+    notify       = optional(bool, true)
+  })
+  default = null
+
+  validation {
+    condition     = var.review_request_delegation == null || contains(["round_robin", "load_balance"], coalesce(var.review_request_delegation.algorithm, "round_robin"))
+    error_message = "Algorithm must be 'round_robin' or 'load_balance'."
+  }
+}

--- a/openspec/changes/add-github-teams-management/tasks.md
+++ b/openspec/changes/add-github-teams-management/tasks.md
@@ -40,7 +40,7 @@ module invocations in `main.tf` (`teams_root`, `teams_level_1`, `teams_level_2`)
 - Create: `modules/team/variables.tf`
 - Create: `modules/team/outputs.tf`
 
-- [ ] **Step 1: Create `modules/team/variables.tf`**
+- [x] **Step 1: Create `modules/team/variables.tf`**
 
 ```hcl
 variable "name" {
@@ -99,7 +99,7 @@ variable "review_request_delegation" {
 }
 ```
 
-- [ ] **Step 2: Create `modules/team/outputs.tf`**
+- [x] **Step 2: Create `modules/team/outputs.tf`**
 
 ```hcl
 output "team_id" {
@@ -113,7 +113,7 @@ output "team_slug" {
 }
 ```
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add modules/team/variables.tf modules/team/outputs.tf
@@ -128,7 +128,7 @@ git commit -m "feat(team): add team submodule variables and outputs"
 
 - Create: `modules/team/main.tf`
 
-- [ ] **Step 1: Create `modules/team/main.tf`**
+- [x] **Step 1: Create `modules/team/main.tf`**
 
 ```hcl
 terraform {
@@ -182,13 +182,13 @@ resource "github_team_settings" "this" {
 }
 ```
 
-- [ ] **Step 2: Run `terraform fmt` on the module**
+- [x] **Step 2: Run `terraform fmt` on the module**
 
 Run: `terraform fmt modules/team/`
 
 Expected: Files formatted (or no changes if already correct).
 
-- [ ] **Step 3: Run `terraform validate` on the module**
+- [x] **Step 3: Run `terraform validate` on the module**
 
 Run: `cd modules/team && terraform init -backend=false && terraform validate`
 
@@ -197,7 +197,7 @@ Expected: `Success! The configuration is valid.`
 Note: This validates syntax and structure. The actual resources require a GitHub provider
 connection at apply time.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add modules/team/main.tf
@@ -217,13 +217,13 @@ github_team_settings resources in modules/team/."
   `locals` block, before the `check` blocks)
 - Create: `config/team/.gitkeep`
 
-- [ ] **Step 1: Create the empty team config directory**
+- [x] **Step 1: Create the empty team config directory**
 
 ```bash
 touch config/team/.gitkeep
 ```
 
-- [ ] **Step 2: Add team config path and file loading to `yaml-config.tf`**
+- [x] **Step 2: Add team config path and file loading to `yaml-config.tf`**
 
 Add the following after the existing `webhook_dir` / `webhook_files` / `webhooks_config` block
 (around line 121), inside the same `locals` block:
@@ -242,7 +242,7 @@ Add the following after the existing `webhook_dir` / `webhook_files` / `webhooks
   ]...)
 ```
 
-- [ ] **Step 3: Add the nested team flattening logic**
+- [x] **Step 3: Add the nested team flattening logic**
 
 Add below the `teams_config_raw` local. This walks up to 3 levels of nesting and produces a flat
 map with tier classification.
@@ -309,7 +309,7 @@ map with tier classification.
   all_teams = merge(local.tier_0_teams, local.tier_1_teams, local.tier_2_teams)
 ```
 
-- [ ] **Step 4: Add team validation checks**
+- [x] **Step 4: Add team validation checks**
 
 Add a new `check` block after the existing `check "template_references"` block at the bottom of
 `yaml-config.tf`:
@@ -355,13 +355,13 @@ check "team_nesting_depth" {
 }
 ```
 
-- [ ] **Step 5: Run `terraform fmt`**
+- [x] **Step 5: Run `terraform fmt`**
 
 Run: `terraform fmt yaml-config.tf`
 
 Expected: File formatted.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add yaml-config.tf config/team/.gitkeep
@@ -379,7 +379,7 @@ three tiers, and validates slug uniqueness and nesting depth."
 
 - Modify: `main.tf`
 
-- [ ] **Step 1: Add tiered team module invocations to `main.tf`**
+- [x] **Step 1: Add tiered team module invocations to `main.tf`**
 
 Add after the existing `github_actions_organization_workflow_permissions` resource block (after
 line 101):
@@ -434,13 +434,13 @@ module "teams_level_2" {
 }
 ```
 
-- [ ] **Step 2: Run `terraform fmt`**
+- [x] **Step 2: Run `terraform fmt`**
 
 Run: `terraform fmt main.tf`
 
 Expected: File formatted.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add main.tf
@@ -459,7 +459,7 @@ Guarded by is_organization flag."
 
 - Modify: `outputs.tf`
 
-- [ ] **Step 1: Add team outputs to `outputs.tf`**
+- [x] **Step 1: Add team outputs to `outputs.tf`**
 
 Add at the end of the file:
 
@@ -494,13 +494,13 @@ output "team_count" {
 }
 ```
 
-- [ ] **Step 2: Run `terraform fmt`**
+- [x] **Step 2: Run `terraform fmt`**
 
 Run: `terraform fmt outputs.tf`
 
 Expected: File formatted.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add outputs.tf
@@ -515,7 +515,7 @@ git commit -m "feat(team): add managed_teams and team_count outputs"
 
 - Modify: `scripts/validate-config.py`
 
-- [ ] **Step 1: Add team directory constant and valid values**
+- [x] **Step 1: Add team directory constant and valid values**
 
 At the top of `scripts/validate-config.py`, after the existing directory constants (line 19),
 add:
@@ -531,7 +531,7 @@ VALID_TEAM_PRIVACIES = ["closed", "secret"]
 VALID_DELEGATION_ALGORITHMS = ["round_robin", "load_balance"]
 ```
 
-- [ ] **Step 2: Add `validate_teams` function**
+- [x] **Step 2: Add `validate_teams` function**
 
 Add after the existing `validate_rulesets` function (after line 204):
 
@@ -624,7 +624,7 @@ def validate_teams(teams: dict) -> tuple[list[str], list[str]]:
     return errors, warnings
 ```
 
-- [ ] **Step 3: Add team cross-reference warning function**
+- [x] **Step 3: Add team cross-reference warning function**
 
 Add after `validate_teams`:
 
@@ -660,7 +660,7 @@ def check_team_cross_references(
     return warnings
 ```
 
-- [ ] **Step 4: Update `main()` to call team validation**
+- [x] **Step 4: Update `main()` to call team validation**
 
 In the `main()` function, after the block that loads rulesets (around line 259), add team
 loading:
@@ -710,13 +710,13 @@ Before the final `sys.exit(0)`, add warning output:
                 print(f"  - {warning}")
 ```
 
-- [ ] **Step 5: Run the validation script to verify it works with no teams**
+- [x] **Step 5: Run the validation script to verify it works with no teams**
 
 Run: `python scripts/validate-config.py`
 
 Expected: `Validation PASSED` with `Teams: 0` in the output.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add scripts/validate-config.py
@@ -734,13 +734,13 @@ overlap, delegation settings, and cross-reference warnings."
 
 - Create: `examples/consumer/config/team/.gitkeep`
 
-- [ ] **Step 1: Create the team directory in the consumer example**
+- [x] **Step 1: Create the team directory in the consumer example**
 
 ```bash
 touch examples/consumer/config/team/.gitkeep
 ```
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
 git add examples/consumer/config/team/.gitkeep
@@ -751,13 +751,13 @@ git commit -m "chore(example): add empty team config directory to consumer examp
 
 ### Task 8: Run Full Validation
 
-- [ ] **Step 1: Run `terraform fmt` on the whole project**
+- [x] **Step 1: Run `terraform fmt` on the whole project**
 
 Run: `terraform fmt -recursive .`
 
 Expected: All files formatted or already correct.
 
-- [ ] **Step 2: Run `terraform validate`**
+- [x] **Step 2: Run `terraform validate`**
 
 Run: `terraform validate`
 
@@ -766,19 +766,19 @@ Expected: `Success! The configuration is valid.`
 Note: This requires `terraform init` to have been run. If providers aren't initialized,
 run `terraform init -backend=false` first.
 
-- [ ] **Step 3: Run the validation script**
+- [x] **Step 3: Run the validation script**
 
 Run: `python scripts/validate-config.py`
 
 Expected: `Validation PASSED` with `Teams: 0`.
 
-- [ ] **Step 4: Run pre-commit hooks**
+- [x] **Step 4: Run pre-commit hooks**
 
 Run: `source .venv/bin/activate && pre-commit run --all-files`
 
 Expected: All checks pass. Fix any formatting issues flagged.
 
-- [ ] **Step 5: If any fixes were needed, commit them**
+- [x] **Step 5: If any fixes were needed, commit them**
 
 ```bash
 git add -A
@@ -789,7 +789,7 @@ git commit -m "style: fix formatting from pre-commit hooks"
 
 ### Task 9: Commit OpenSpec Artifacts
 
-- [ ] **Step 1: Stage and commit all OpenSpec change files**
+- [x] **Step 1: Stage and commit all OpenSpec change files**
 
 ```bash
 git add openspec/changes/add-github-teams-management/

--- a/outputs.tf
+++ b/outputs.tf
@@ -87,6 +87,6 @@ output "managed_teams" {
 }
 
 output "team_count" {
-  description = "Total number of managed teams"
-  value       = length(local.all_teams)
+  description = "Total number of managed teams (0 when is_organization is false)"
+  value       = local.is_organization ? length(local.all_teams) : 0
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,3 +61,32 @@ output "duplicate_key_warnings" {
     } : null
   } : null
 }
+
+output "managed_teams" {
+  description = "Map of managed team slugs to their IDs"
+  value = merge(
+    {
+      for slug, team in module.teams_root : slug => {
+        id   = team.team_id
+        slug = team.team_slug
+      }
+    },
+    {
+      for slug, team in module.teams_level_1 : slug => {
+        id   = team.team_id
+        slug = team.team_slug
+      }
+    },
+    {
+      for slug, team in module.teams_level_2 : slug => {
+        id   = team.team_id
+        slug = team.team_slug
+      }
+    }
+  )
+}
+
+output "team_count" {
+  description = "Total number of managed teams"
+  value       = length(local.all_teams)
+}

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -209,96 +209,219 @@ def validate_rulesets(rulesets: dict) -> list[str]:
     return errors
 
 
-def flatten_teams(teams: dict, depth: int = 0, parent: str = None) -> list[dict]:
-    """Recursively flatten nested team definitions."""
-    result = []
+_SLUG_RE = re.compile(r"^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$")
+
+
+def load_team_directory(directory: Path) -> dict:
+    """Load team configs with per-file duplicate slug detection.
+
+    Unlike load_yaml_directory (which silently overwrites duplicates), this
+    raises ValueError when the same top-level slug appears in more than one file.
+    """
+    teams: dict = {}
+    sources: dict = {}
+    for team_file in sorted(directory.glob("*.yml")):
+        file_teams = load_yaml(team_file)
+        if not file_teams:
+            continue
+        if not isinstance(file_teams, dict):
+            raise ValueError(
+                f"Team configuration file must contain a mapping: {team_file.name}"
+            )
+        for slug, team_config in file_teams.items():
+            if slug in teams:
+                raise ValueError(
+                    f"Duplicate top-level team slug '{slug}' found in "
+                    f"'{sources[slug].name}' and '{team_file.name}'. "
+                    f"Each team slug must appear in only one file."
+                )
+            teams[slug] = team_config
+            sources[slug] = team_file
+    return teams
+
+
+def flatten_teams(
+    teams: dict, depth: int = 0, parent: str | None = None
+) -> tuple[list[dict], list[str]]:
+    """Recursively flatten nested team definitions.
+
+    Returns (flat_list, type_errors) so callers learn about malformed entries
+    instead of silently skipping them.
+    """
+    result: list[dict] = []
+    errors: list[str] = []
+
     for slug, config in teams.items():
         if not isinstance(config, dict):
+            errors.append(
+                f"teams: Team '{slug}' configuration must be a mapping, "
+                f"got {type(config).__name__!r}"
+            )
             continue
+
         result.append(
-            {
-                "slug": slug,
-                "config": config,
-                "depth": depth,
-                "parent": parent,
-            }
+            {"slug": slug, "config": config, "depth": depth, "parent": parent}
         )
-        # Recurse into nested teams
-        nested = config.get("teams", {})
-        if isinstance(nested, dict) and nested:
-            result.extend(flatten_teams(nested, depth + 1, slug))
-    return result
+
+        nested = config.get("teams")
+        if nested is None:
+            pass  # key absent or explicitly null — treat as no children
+        elif isinstance(nested, dict):
+            child_result, child_errors = flatten_teams(nested, depth + 1, slug)
+            result.extend(child_result)
+            errors.extend(child_errors)
+        else:
+            errors.append(
+                f"teams: Team '{slug}' field 'teams' must be a mapping, "
+                f"got {type(nested).__name__!r}"
+            )
+
+    return result, errors
 
 
-def validate_teams(teams: dict) -> tuple[list[str], list[str]]:
-    """Validate teams configuration. Returns (errors, warnings)."""
-    errors = []
-    warnings = []
+def validate_teams(
+    teams: dict,
+    flat_teams: list[dict] | None = None,
+    flat_errors: list[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Validate teams configuration. Returns (errors, warnings).
+
+    Pass pre-computed flat_teams / flat_errors to avoid re-flattening.
+    """
+    errors: list[str] = list(flat_errors or [])
+    warnings: list[str] = []
 
     if not teams:
         return errors, warnings
 
-    flat = flatten_teams(teams)
+    if flat_teams is None:
+        flat_teams, type_errors = flatten_teams(teams)
+        errors.extend(type_errors)
 
-    # Check for duplicate slugs
-    slugs = [t["slug"] for t in flat]
-    seen = set()
-    for slug in slugs:
+    # Check for duplicate slugs across the hierarchy
+    seen: set[str] = set()
+    for t in flat_teams:
+        slug = t["slug"]
         if slug in seen:
             errors.append(f"teams: Duplicate team slug '{slug}' found across hierarchy")
         seen.add(slug)
 
     # Check max nesting depth
-    for team in flat:
-        if team["depth"] > 2:
+    for t in flat_teams:
+        if t["depth"] > 2:
             errors.append(
-                f"teams: Team '{team['slug']}' exceeds maximum nesting depth of 3 levels "
-                f"(depth {team['depth'] + 1})"
+                f"teams: Team '{t['slug']}' exceeds maximum nesting depth of 3 levels "
+                f"(depth {t['depth'] + 1})"
             )
 
-    # Validate each team's fields
-    _slug_re = re.compile(r"^[a-z0-9][a-z0-9\-]*$")
-    for team in flat:
-        slug = team["slug"]
-        config = team["config"]
+    # Field-level validation
+    for t in flat_teams:
+        slug = t["slug"]
+        config = t["config"]
 
-        # Validate slug characters (GitHub normalises slugs; mismatches cause confusing state)
-        if not _slug_re.match(slug):
+        # Slug format (GitHub normalises slugs; mismatches cause perpetual plan diff)
+        if not _SLUG_RE.match(slug):
             errors.append(
                 f"teams: Team slug '{slug}' contains invalid characters. "
-                f"Use only lowercase letters, digits, and hyphens (e.g. 'platform-team')."
+                f"Use only lowercase letters, digits, and hyphens; "
+                f"must not start or end with a hyphen (e.g. 'platform-team')."
             )
 
         if "description" not in config:
             errors.append(f"teams: Team '{slug}' missing required field 'description'")
 
         privacy = config.get("privacy")
-        if privacy and privacy not in VALID_TEAM_PRIVACIES:
-            errors.append(
-                f"teams: Team '{slug}' has invalid privacy '{privacy}'. "
-                f"Valid values: {', '.join(VALID_TEAM_PRIVACIES)}"
-            )
-
-        # Validate no overlap between members and maintainers
-        members = set(config.get("members", []))
-        maintainers = set(config.get("maintainers", []))
-        overlap = members & maintainers
-        if overlap:
-            errors.append(
-                f"teams: Team '{slug}' has users in both members and maintainers: "
-                f"{', '.join(sorted(overlap))}"
-            )
-
-        # Validate review_request_delegation
-        # 'enabled' is optional (defaults to true); only validate algorithm when present
-        delegation = config.get("review_request_delegation")
-        if isinstance(delegation, dict):
-            algorithm = delegation.get("algorithm")
-            if algorithm and algorithm not in VALID_DELEGATION_ALGORITHMS:
+        if privacy is not None:
+            if not isinstance(privacy, str):
                 errors.append(
-                    f"teams: Team '{slug}' has invalid delegation algorithm '{algorithm}'. "
-                    f"Valid values: {', '.join(VALID_DELEGATION_ALGORITHMS)}"
+                    f"teams: Team '{slug}' field 'privacy' must be a string, "
+                    f"got {type(privacy).__name__!r}"
                 )
+            elif privacy not in VALID_TEAM_PRIVACIES:
+                errors.append(
+                    f"teams: Team '{slug}' has invalid privacy '{privacy}'. "
+                    f"Valid values: {', '.join(VALID_TEAM_PRIVACIES)}"
+                )
+
+        # members / maintainers: must be list of strings when present
+        for field in ("members", "maintainers"):
+            value = config.get(field)
+            if value is None:
+                continue
+            if not isinstance(value, list):
+                errors.append(
+                    f"teams: Team '{slug}' field '{field}' must be a list, "
+                    f"got {type(value).__name__!r}"
+                )
+            elif not all(isinstance(u, str) for u in value):
+                errors.append(
+                    f"teams: Team '{slug}' field '{field}' must be a list of strings"
+                )
+
+        # Overlap check (only when both are valid lists)
+        raw_members = config.get("members")
+        raw_maintainers = config.get("maintainers")
+        if isinstance(raw_members, list) and isinstance(raw_maintainers, list):
+            overlap = set(raw_members) & set(raw_maintainers)
+            if overlap:
+                errors.append(
+                    f"teams: Team '{slug}' has users in both members and maintainers: "
+                    f"{', '.join(sorted(overlap))}"
+                )
+
+        # review_request_delegation: full type + value validation
+        raw_delegation = config.get("review_request_delegation")
+        if raw_delegation is not None:
+            if not isinstance(raw_delegation, dict):
+                errors.append(
+                    f"teams: Team '{slug}' field 'review_request_delegation' must be "
+                    f"a mapping, got {type(raw_delegation).__name__!r}"
+                )
+            else:
+                delegation = raw_delegation
+
+                enabled = delegation.get("enabled")
+                if enabled is not None and not isinstance(enabled, bool):
+                    errors.append(
+                        f"teams: Team '{slug}' field "
+                        f"'review_request_delegation.enabled' must be a boolean"
+                    )
+
+                algorithm = delegation.get("algorithm")
+                if algorithm is not None:
+                    if not isinstance(algorithm, str):
+                        errors.append(
+                            f"teams: Team '{slug}' field "
+                            f"'review_request_delegation.algorithm' must be a string"
+                        )
+                    elif algorithm not in VALID_DELEGATION_ALGORITHMS:
+                        errors.append(
+                            f"teams: Team '{slug}' has invalid delegation algorithm "
+                            f"'{algorithm}'. Valid values: "
+                            f"{', '.join(VALID_DELEGATION_ALGORITHMS)}"
+                        )
+
+                member_count = delegation.get("member_count")
+                if member_count is not None:
+                    if not isinstance(member_count, int) or isinstance(
+                        member_count, bool
+                    ):
+                        errors.append(
+                            f"teams: Team '{slug}' field "
+                            f"'review_request_delegation.member_count' must be an integer"
+                        )
+                    elif member_count <= 0:
+                        errors.append(
+                            f"teams: Team '{slug}' field "
+                            f"'review_request_delegation.member_count' must be greater than 0"
+                        )
+
+                notify = delegation.get("notify")
+                if notify is not None and not isinstance(notify, bool):
+                    errors.append(
+                        f"teams: Team '{slug}' field "
+                        f"'review_request_delegation.notify' must be a boolean"
+                    )
 
     return errors, warnings
 
@@ -388,9 +511,9 @@ def main():
         else:
             rulesets = load_yaml(CONFIG_DIR / "rulesets.yml")
 
-        # Load teams (optional directory)
+        # Load teams (optional directory) with per-file duplicate detection
         if TEAM_DIR.exists():
-            teams = load_yaml_directory(TEAM_DIR)
+            teams = load_team_directory(TEAM_DIR)
         else:
             teams = {}
     except ValueError as e:
@@ -403,10 +526,12 @@ def main():
     all_errors.extend(validate_rulesets(rulesets))
     all_errors.extend(validate_repositories(repos, groups, rulesets))
 
-    # Flatten once; reused by validate_teams, cross-ref check, and summary output
-    flat_teams = flatten_teams(teams) if teams else []
+    # Flatten once; pass into validate_teams so it isn't re-computed internally
+    flat_teams, flat_errors = flatten_teams(teams) if teams else ([], [])
 
-    team_errors, team_warnings = validate_teams(teams)
+    team_errors, team_warnings = validate_teams(
+        teams, flat_teams=flat_teams, flat_errors=flat_errors
+    )
     all_errors.extend(team_errors)
 
     # Cross-reference check for team slugs (warnings only)

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -7,6 +7,7 @@ Usage:
     python scripts/validate-config.py --strict
 """
 
+import re
 import sys
 import yaml
 from pathlib import Path
@@ -256,9 +257,17 @@ def validate_teams(teams: dict) -> tuple[list[str], list[str]]:
             )
 
     # Validate each team's fields
+    _slug_re = re.compile(r"^[a-z0-9][a-z0-9\-]*$")
     for team in flat:
         slug = team["slug"]
         config = team["config"]
+
+        # Validate slug characters (GitHub normalises slugs; mismatches cause confusing state)
+        if not _slug_re.match(slug):
+            errors.append(
+                f"teams: Team slug '{slug}' contains invalid characters. "
+                f"Use only lowercase letters, digits, and hyphens (e.g. 'platform-team')."
+            )
 
         if "description" not in config:
             errors.append(f"teams: Team '{slug}' missing required field 'description'")
@@ -281,13 +290,9 @@ def validate_teams(teams: dict) -> tuple[list[str], list[str]]:
             )
 
         # Validate review_request_delegation
+        # 'enabled' is optional (defaults to true); only validate algorithm when present
         delegation = config.get("review_request_delegation")
         if isinstance(delegation, dict):
-            if "enabled" not in delegation:
-                errors.append(
-                    f"teams: Team '{slug}' review_request_delegation missing "
-                    f"required field 'enabled'"
-                )
             algorithm = delegation.get("algorithm")
             if algorithm and algorithm not in VALID_DELEGATION_ALGORITHMS:
                 errors.append(
@@ -398,13 +403,15 @@ def main():
     all_errors.extend(validate_rulesets(rulesets))
     all_errors.extend(validate_repositories(repos, groups, rulesets))
 
+    # Flatten once; reused by validate_teams, cross-ref check, and summary output
+    flat_teams = flatten_teams(teams) if teams else []
+
     team_errors, team_warnings = validate_teams(teams)
     all_errors.extend(team_errors)
 
     # Cross-reference check for team slugs (warnings only)
     team_xref_warnings = []
-    if teams:
-        flat_teams = flatten_teams(teams)
+    if flat_teams:
         managed_slugs = {t["slug"] for t in flat_teams}
         team_xref_warnings = check_team_cross_references(repos, groups, managed_slugs)
 
@@ -425,11 +432,11 @@ def main():
         print(f"  - Groups: {len(groups)}")
         print(f"  - Repositories: {len(repos)}")
         print(f"  - Rulesets: {len(rulesets)}")
-        print(f"  - Teams: {len(flatten_teams(teams)) if teams else 0}")
+        print(f"  - Teams: {len(flat_teams)}")
 
         # Print warnings (non-fatal)
         all_warnings = team_warnings
-        if teams:
+        if flat_teams:
             all_warnings.extend(team_xref_warnings)
         if all_warnings:
             print()

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -17,6 +17,7 @@ CONFIG_DIR = Path(__file__).parent.parent / "config"
 GROUP_DIR = CONFIG_DIR / "group"
 REPOSITORY_DIR = CONFIG_DIR / "repository"
 RULESET_DIR = CONFIG_DIR / "ruleset"
+TEAM_DIR = CONFIG_DIR / "team"
 
 VALID_VISIBILITIES = ["public", "private", "internal"]
 VALID_PERMISSIONS = ["pull", "triage", "push", "maintain", "admin"]
@@ -35,6 +36,9 @@ VALID_RULE_TYPES = [
     "commit_author_email_pattern",
     "committer_email_pattern",
 ]
+
+VALID_TEAM_PRIVACIES = ["closed", "secret"]
+VALID_DELEGATION_ALGORITHMS = ["round_robin", "load_balance"]
 
 
 def load_yaml(filepath: Path) -> dict:
@@ -204,6 +208,127 @@ def validate_rulesets(rulesets: dict) -> list[str]:
     return errors
 
 
+def flatten_teams(teams: dict, depth: int = 0, parent: str = None) -> list[dict]:
+    """Recursively flatten nested team definitions."""
+    result = []
+    for slug, config in teams.items():
+        if not isinstance(config, dict):
+            continue
+        result.append(
+            {
+                "slug": slug,
+                "config": config,
+                "depth": depth,
+                "parent": parent,
+            }
+        )
+        # Recurse into nested teams
+        nested = config.get("teams", {})
+        if isinstance(nested, dict) and nested:
+            result.extend(flatten_teams(nested, depth + 1, slug))
+    return result
+
+
+def validate_teams(teams: dict) -> tuple[list[str], list[str]]:
+    """Validate teams configuration. Returns (errors, warnings)."""
+    errors = []
+    warnings = []
+
+    if not teams:
+        return errors, warnings
+
+    flat = flatten_teams(teams)
+
+    # Check for duplicate slugs
+    slugs = [t["slug"] for t in flat]
+    seen = set()
+    for slug in slugs:
+        if slug in seen:
+            errors.append(f"teams: Duplicate team slug '{slug}' found across hierarchy")
+        seen.add(slug)
+
+    # Check max nesting depth
+    for team in flat:
+        if team["depth"] > 2:
+            errors.append(
+                f"teams: Team '{team['slug']}' exceeds maximum nesting depth of 3 levels "
+                f"(depth {team['depth'] + 1})"
+            )
+
+    # Validate each team's fields
+    for team in flat:
+        slug = team["slug"]
+        config = team["config"]
+
+        if "description" not in config:
+            errors.append(f"teams: Team '{slug}' missing required field 'description'")
+
+        privacy = config.get("privacy")
+        if privacy and privacy not in VALID_TEAM_PRIVACIES:
+            errors.append(
+                f"teams: Team '{slug}' has invalid privacy '{privacy}'. "
+                f"Valid values: {', '.join(VALID_TEAM_PRIVACIES)}"
+            )
+
+        # Validate no overlap between members and maintainers
+        members = set(config.get("members", []))
+        maintainers = set(config.get("maintainers", []))
+        overlap = members & maintainers
+        if overlap:
+            errors.append(
+                f"teams: Team '{slug}' has users in both members and maintainers: "
+                f"{', '.join(sorted(overlap))}"
+            )
+
+        # Validate review_request_delegation
+        delegation = config.get("review_request_delegation")
+        if isinstance(delegation, dict):
+            if "enabled" not in delegation:
+                errors.append(
+                    f"teams: Team '{slug}' review_request_delegation missing "
+                    f"required field 'enabled'"
+                )
+            algorithm = delegation.get("algorithm")
+            if algorithm and algorithm not in VALID_DELEGATION_ALGORITHMS:
+                errors.append(
+                    f"teams: Team '{slug}' has invalid delegation algorithm '{algorithm}'. "
+                    f"Valid values: {', '.join(VALID_DELEGATION_ALGORITHMS)}"
+                )
+
+    return errors, warnings
+
+
+def check_team_cross_references(
+    repos: dict, groups: dict, managed_team_slugs: set
+) -> list[str]:
+    """Warn when repos/groups reference team slugs not in config/team/."""
+    warnings = []
+
+    if not managed_team_slugs:
+        return warnings
+
+    # Collect all referenced team slugs from repos and groups
+    referenced = set()
+    for repo_name, repo_config in repos.items():
+        if isinstance(repo_config, dict):
+            for slug in repo_config.get("teams", {}).keys():
+                referenced.add((slug, f"repository '{repo_name}'"))
+
+    for group_name, group_config in groups.items():
+        if isinstance(group_config, dict):
+            for slug in group_config.get("teams", {}).keys():
+                referenced.add((slug, f"group '{group_name}'"))
+
+    for slug, source in referenced:
+        if slug not in managed_team_slugs:
+            warnings.append(
+                f"teams: {source} references team '{slug}' which is not defined in "
+                f"config/team/ (may be managed externally)"
+            )
+
+    return warnings
+
+
 def main():
     """Main validation entry point."""
     strict = "--strict" in sys.argv
@@ -257,6 +382,12 @@ def main():
             rulesets = load_yaml_directory(RULESET_DIR)
         else:
             rulesets = load_yaml(CONFIG_DIR / "rulesets.yml")
+
+        # Load teams (optional directory)
+        if TEAM_DIR.exists():
+            teams = load_yaml_directory(TEAM_DIR)
+        else:
+            teams = {}
     except ValueError as e:
         print(f"ERROR: {e}")
         sys.exit(1)
@@ -266,6 +397,16 @@ def main():
     all_errors.extend(validate_groups(groups))
     all_errors.extend(validate_rulesets(rulesets))
     all_errors.extend(validate_repositories(repos, groups, rulesets))
+
+    team_errors, team_warnings = validate_teams(teams)
+    all_errors.extend(team_errors)
+
+    # Cross-reference check for team slugs (warnings only)
+    team_xref_warnings = []
+    if teams:
+        flat_teams = flatten_teams(teams)
+        managed_slugs = {t["slug"] for t in flat_teams}
+        team_xref_warnings = check_team_cross_references(repos, groups, managed_slugs)
 
     # Report results
     if all_errors:
@@ -284,6 +425,18 @@ def main():
         print(f"  - Groups: {len(groups)}")
         print(f"  - Repositories: {len(repos)}")
         print(f"  - Rulesets: {len(rulesets)}")
+        print(f"  - Teams: {len(flatten_teams(teams)) if teams else 0}")
+
+        # Print warnings (non-fatal)
+        all_warnings = team_warnings
+        if teams:
+            all_warnings.extend(team_xref_warnings)
+        if all_warnings:
+            print()
+            print("Warnings:")
+            for warning in all_warnings:
+                print(f"  - {warning}")
+
         sys.exit(0)
 
 

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -127,6 +127,25 @@ locals {
     fileset(local.team_dir, "*.yml"),
     toset([])
   )
+  # Load per-file for duplicate-slug detection (mirrors repo/group/ruleset pattern)
+  team_configs_by_file = {
+    for f in sort(tolist(local.team_files)) :
+    f => try(yamldecode(file("${local.team_dir}/${f}")), {})
+  }
+  duplicate_team_slugs = {
+    for slug in distinct(flatten([
+      for f, config in local.team_configs_by_file :
+      config != null ? keys(config) : []
+    ])) :
+    slug => [
+      for f, config in local.team_configs_by_file :
+      f if config != null && contains(keys(config), slug)
+    ]
+    if length([
+      for f, config in local.team_configs_by_file :
+      f if config != null && contains(keys(config), slug)
+    ]) > 1
+  }
   teams_config_raw = merge([
     for f in sort(tolist(local.team_files)) :
     try(yamldecode(file("${local.team_dir}/${f}")), {})
@@ -140,15 +159,18 @@ locals {
   # Tier 0: root teams (no parent)
   # Tier 1: children of tier 0
   # Tier 2: children of tier 1 (max depth)
+  #
+  # All optional list/map fields use coalesce(lookup(..., null), fallback) so that
+  # an explicit `key: null` in YAML is treated the same as an absent key.
 
   # Tier 0 - root level teams
   tier_0_teams = {
     for slug, config in local.teams_config_raw : slug => {
       name                      = slug
       description               = config.description
-      privacy                   = lookup(config, "privacy", "closed")
-      members                   = lookup(config, "members", [])
-      maintainers               = lookup(config, "maintainers", [])
+      privacy                   = coalesce(lookup(config, "privacy", null), "closed")
+      members                   = coalesce(lookup(config, "members", null), [])
+      maintainers               = coalesce(lookup(config, "maintainers", null), [])
       review_request_delegation = lookup(config, "review_request_delegation", null)
       parent_slug               = null
       tier                      = 0
@@ -158,12 +180,12 @@ locals {
   # Tier 1 - children of root teams
   tier_1_teams = merge([
     for parent_slug, parent_config in local.teams_config_raw : {
-      for child_slug, child_config in lookup(parent_config, "teams", {}) : child_slug => {
+      for child_slug, child_config in coalesce(lookup(parent_config, "teams", null), {}) : child_slug => {
         name                      = child_slug
         description               = child_config.description
-        privacy                   = lookup(child_config, "privacy", "closed")
-        members                   = lookup(child_config, "members", [])
-        maintainers               = lookup(child_config, "maintainers", [])
+        privacy                   = coalesce(lookup(child_config, "privacy", null), "closed")
+        members                   = coalesce(lookup(child_config, "members", null), [])
+        maintainers               = coalesce(lookup(child_config, "maintainers", null), [])
         review_request_delegation = lookup(child_config, "review_request_delegation", null)
         parent_slug               = parent_slug
         tier                      = 1
@@ -174,13 +196,13 @@ locals {
   # Tier 2 - grandchildren (children of tier 1)
   tier_2_teams = merge([
     for parent_slug, parent_config in local.teams_config_raw : merge([
-      for child_slug, child_config in lookup(parent_config, "teams", {}) : {
-        for grandchild_slug, grandchild_config in lookup(child_config, "teams", {}) : grandchild_slug => {
+      for child_slug, child_config in coalesce(lookup(parent_config, "teams", null), {}) : {
+        for grandchild_slug, grandchild_config in coalesce(lookup(child_config, "teams", null), {}) : grandchild_slug => {
           name                      = grandchild_slug
           description               = grandchild_config.description
-          privacy                   = lookup(grandchild_config, "privacy", "closed")
-          members                   = lookup(grandchild_config, "members", [])
-          maintainers               = lookup(grandchild_config, "maintainers", [])
+          privacy                   = coalesce(lookup(grandchild_config, "privacy", null), "closed")
+          members                   = coalesce(lookup(grandchild_config, "members", null), [])
+          maintainers               = coalesce(lookup(grandchild_config, "maintainers", null), [])
           review_request_delegation = lookup(grandchild_config, "review_request_delegation", null)
           parent_slug               = child_slug
           tier                      = 2
@@ -197,12 +219,12 @@ locals {
   # length(tier_N_teams) < tier_N_raw_count means a collision occurred.
   tier_1_raw_count = length(flatten([
     for parent_slug, parent_config in local.teams_config_raw :
-    keys(lookup(parent_config, "teams", {}))
+    keys(coalesce(lookup(parent_config, "teams", null), {}))
   ]))
   tier_2_raw_count = length(flatten([
     for parent_slug, parent_config in local.teams_config_raw : flatten([
-      for child_slug, child_config in lookup(parent_config, "teams", {}) :
-      keys(lookup(child_config, "teams", {}))
+      for child_slug, child_config in coalesce(lookup(parent_config, "teams", null), {}) :
+      keys(coalesce(lookup(child_config, "teams", null), {}))
     ])
   ]))
 
@@ -704,6 +726,15 @@ locals {
       webhooks = local.merged_webhooks[repo_name]
 
     }
+  }
+}
+
+# Validate no duplicate top-level team slugs across config/team/*.yml files
+# Last-file-wins merge silently drops definitions when two files share a top-level slug.
+check "duplicate_team_file_slugs" {
+  assert {
+    condition     = length(local.duplicate_team_slugs) == 0
+    error_message = "Duplicate top-level team slugs found across config/team/ files: ${join(", ", keys(local.duplicate_team_slugs))}. Each team slug must appear in only one file."
   }
 }
 

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -192,6 +192,20 @@ locals {
   # Combined flat map of all teams (for validation and outputs)
   all_teams = merge(local.tier_0_teams, local.tier_1_teams, local.tier_2_teams)
 
+  # Raw child counts BEFORE merge - used to detect intra-tier duplicate slugs.
+  # merge([...]) silently drops entries when two parents share a child slug, so
+  # length(tier_N_teams) < tier_N_raw_count means a collision occurred.
+  tier_1_raw_count = length(flatten([
+    for parent_slug, parent_config in local.teams_config_raw :
+    keys(lookup(parent_config, "teams", {}))
+  ]))
+  tier_2_raw_count = length(flatten([
+    for parent_slug, parent_config in local.teams_config_raw : flatten([
+      for child_slug, child_config in lookup(parent_config, "teams", {}) :
+      keys(lookup(child_config, "teams", {}))
+    ])
+  ]))
+
   # Extract values from YAML
   github_org      = local.common_config.organization
   is_organization = lookup(local.common_config, "is_organization", true)
@@ -693,7 +707,8 @@ locals {
   }
 }
 
-# Validate no duplicate team slugs across tiers
+# Validate no duplicate team slugs across tiers (cross-tier check)
+# Catches cases where a slug appears in multiple tiers (e.g. tier 0 and tier 1).
 check "team_slug_uniqueness" {
   assert {
     condition = (
@@ -701,6 +716,19 @@ check "team_slug_uniqueness" {
       length(local.tier_0_teams) + length(local.tier_1_teams) + length(local.tier_2_teams)
     )
     error_message = "Duplicate team slugs detected across hierarchy levels. Each team slug must be unique."
+  }
+}
+
+# Validate no duplicate slugs within a tier (intra-tier check)
+# merge([...]) silently drops one entry when two parents share a child slug.
+# These checks compare the post-merge count with the raw pre-merge count.
+check "team_slug_uniqueness_intra_tier" {
+  assert {
+    condition = (
+      length(local.tier_1_teams) == local.tier_1_raw_count &&
+      length(local.tier_2_teams) == local.tier_2_raw_count
+    )
+    error_message = "Duplicate team slugs detected within a tier. Two parent teams cannot have child teams with the same slug."
   }
 }
 

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -120,6 +120,78 @@ locals {
     try(yamldecode(file("${local.webhook_dir}/${f}")), {})
   ]...)
 
+  # Load team definitions from config/team/ directory
+  # Directory is optional - missing directory results in empty map
+  team_dir = "${local.config_base_path}/team"
+  team_files = try(
+    fileset(local.team_dir, "*.yml"),
+    toset([])
+  )
+  teams_config_raw = merge([
+    for f in sort(tolist(local.team_files)) :
+    try(yamldecode(file("${local.team_dir}/${f}")), {})
+  ]...)
+
+  # Flatten nested team hierarchy into a tiered flat map
+  # Input: nested YAML where child teams are under parent's `teams` key
+  # Output: flat map of slug => { description, privacy, members, maintainers,
+  #          review_request_delegation, parent_slug, tier }
+  #
+  # Tier 0: root teams (no parent)
+  # Tier 1: children of tier 0
+  # Tier 2: children of tier 1 (max depth)
+
+  # Tier 0 - root level teams
+  tier_0_teams = {
+    for slug, config in local.teams_config_raw : slug => {
+      name                      = slug
+      description               = config.description
+      privacy                   = lookup(config, "privacy", "closed")
+      members                   = lookup(config, "members", [])
+      maintainers               = lookup(config, "maintainers", [])
+      review_request_delegation = lookup(config, "review_request_delegation", null)
+      parent_slug               = null
+      tier                      = 0
+    }
+  }
+
+  # Tier 1 - children of root teams
+  tier_1_teams = merge([
+    for parent_slug, parent_config in local.teams_config_raw : {
+      for child_slug, child_config in lookup(parent_config, "teams", {}) : child_slug => {
+        name                      = child_slug
+        description               = child_config.description
+        privacy                   = lookup(child_config, "privacy", "closed")
+        members                   = lookup(child_config, "members", [])
+        maintainers               = lookup(child_config, "maintainers", [])
+        review_request_delegation = lookup(child_config, "review_request_delegation", null)
+        parent_slug               = parent_slug
+        tier                      = 1
+      }
+    }
+  ]...)
+
+  # Tier 2 - grandchildren (children of tier 1)
+  tier_2_teams = merge([
+    for parent_slug, parent_config in local.teams_config_raw : merge([
+      for child_slug, child_config in lookup(parent_config, "teams", {}) : {
+        for grandchild_slug, grandchild_config in lookup(child_config, "teams", {}) : grandchild_slug => {
+          name                      = grandchild_slug
+          description               = grandchild_config.description
+          privacy                   = lookup(grandchild_config, "privacy", "closed")
+          members                   = lookup(grandchild_config, "members", [])
+          maintainers               = lookup(grandchild_config, "maintainers", [])
+          review_request_delegation = lookup(grandchild_config, "review_request_delegation", null)
+          parent_slug               = child_slug
+          tier                      = 2
+        }
+      }
+    ]...)
+  ]...)
+
+  # Combined flat map of all teams (for validation and outputs)
+  all_teams = merge(local.tier_0_teams, local.tier_1_teams, local.tier_2_teams)
+
   # Extract values from YAML
   github_org      = local.common_config.organization
   is_organization = lookup(local.common_config, "is_organization", true)
@@ -618,6 +690,45 @@ locals {
       webhooks = local.merged_webhooks[repo_name]
 
     }
+  }
+}
+
+# Validate no duplicate team slugs across tiers
+check "team_slug_uniqueness" {
+  assert {
+    condition = (
+      length(local.all_teams) ==
+      length(local.tier_0_teams) + length(local.tier_1_teams) + length(local.tier_2_teams)
+    )
+    error_message = "Duplicate team slugs detected across hierarchy levels. Each team slug must be unique."
+  }
+}
+
+# Validate no user appears in both members and maintainers for any team
+check "team_member_maintainer_overlap" {
+  assert {
+    condition = length([
+      for slug, team in local.all_teams : slug
+      if length(setintersection(toset(team.members), toset(team.maintainers))) > 0
+    ]) == 0
+    error_message = "Some teams have users in both members and maintainers. A user can only have one role per team."
+  }
+}
+
+# Validate no teams nested deeper than 3 levels
+# This checks that tier 2 teams have no nested `teams` key with content
+check "team_nesting_depth" {
+  assert {
+    condition = length(flatten([
+      for parent_slug, parent_config in local.teams_config_raw : flatten([
+        for child_slug, child_config in lookup(parent_config, "teams", {}) : [
+          for grandchild_slug, grandchild_config in lookup(child_config, "teams", {}) :
+          grandchild_slug
+          if length(lookup(grandchild_config, "teams", {})) > 0
+        ]
+      ])
+    ])) == 0
+    error_message = "Team nesting exceeds maximum depth of 3 levels. Reorganize your team hierarchy."
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `modules/team/` submodule managing `github_team`, `github_team_membership`, and `github_team_settings` resources
- Adds `config/team/` YAML directory for defining teams with nested hierarchy (up to 3 levels deep), membership, and PR review delegation
- Wires three tiered module invocations in `main.tf` (`teams_root`, `teams_level_1`, `teams_level_2`) for correct dependency ordering, guarded by `is_organization`
- Extends `yaml-config.tf` with team loading, flattening, tier classification, and three `check` blocks (slug uniqueness, member/maintainer overlap, nesting depth)
- Adds `managed_teams` and `team_count` outputs
- Extends `scripts/validate-config.py` with team schema validation and cross-reference warnings

## Test Plan

- [x] `terraform fmt -recursive .` — no changes
- [x] `terraform validate` — `Success! The configuration is valid.`
- [x] `python3 scripts/validate-config.py` — `Validation PASSED`, `Teams: 0`
- [x] `modules/team/` standalone `terraform validate` — `Success!`
- [ ] Reviewer: spot-check tiered module wiring and cross-reference validation logic

## Notes

- This is purely additive — no existing resources are affected
- Teams are optional: if `config/team/` is absent or empty, no team resources are created
- SCIM/SSO users should not populate `members`/`maintainers` fields (documented in design)

Closes #27