### PR TITLE
feat: add repository partitioning and API rate limit mitigation

### DIFF
--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -1,0 +1,205 @@
+# Scaling Guide
+
+This guide covers API rate limit considerations, provider tuning, and the
+repository partitioning feature for managing large GitHub organisations with
+this module.
+
+## API Cost Per Repository
+
+Each `terraform plan` (or `apply`) triggers a read refresh for every repository
+in scope. The following resources are read per repository:
+
+| Resource | API calls | Notes |
+|---|---|---|
+| `github_repository` | 1 | Core repository data |
+| `github_team_repository` | 1 per team | Varies by team count per repo |
+| `github_repository_collaborator` | 1 per collaborator | Varies by collaborator count |
+| `github_repository_ruleset` | 1 per ruleset | Varies by ruleset count |
+| `github_actions_repository_permissions` | 1 | Only when actions config is set |
+| `github_repository_webhook` | 1 per webhook | Varies by webhook count |
+
+**Typical baseline:** ~7 API calls per repository (1 repo + 2 teams + 1 collaborator
++ 1 ruleset + 1 actions + 1 webhook). Repos with no teams, rulesets, or webhooks
+cost as few as 1–2 calls.
+
+## Rate Limit Thresholds
+
+GitHub enforces per-hour rate limits on authenticated API requests:
+
+| Auth method | Limit |
+|---|---|
+| Personal Access Token (PAT) | 5,000 requests / hour |
+| GitHub App installation token | 15,000 requests / hour |
+
+Estimated total API calls for a single `terraform plan` at various org sizes
+(assuming ~7 calls per repo):
+
+| Repositories | Estimated calls | Within PAT limit | Within App limit |
+|---|---|---|---|
+| 100 | ~700 | ✅ Yes | ✅ Yes |
+| 500 | ~3,500 | ✅ Yes | ✅ Yes |
+| 700 | ~4,900 | ⚠️ Near limit | ✅ Yes |
+| 1,000 | ~7,000 | ❌ Exceeds | ✅ Yes |
+| 2,000 | ~14,000 | ❌ Exceeds | ⚠️ Near limit |
+| 2,500+ | ~17,500+ | ❌ Exceeds | ❌ Exceeds |
+
+**Recommendation:** Use a GitHub App token for organisations with 500+ repositories.
+For 2,000+ repositories, combine App tokens with repository partitioning.
+
+## Provider Tuning
+
+The `integrations/github` Terraform provider supports configurable delays between
+API calls to avoid hitting rate limits. Add these to your `provider "github"` block:
+
+### Small organisations (< 100 repositories)
+
+```hcl
+provider "github" {
+  owner = "your-org"
+  # No delays needed at this scale
+}
+```
+
+### Medium organisations (100–500 repositories)
+
+```hcl
+provider "github" {
+  owner          = "your-org"
+  read_delay_ms  = 0
+  write_delay_ms = 100
+}
+```
+
+### Large organisations (500+ repositories)
+
+```hcl
+provider "github" {
+  owner          = "your-org"
+  read_delay_ms  = 50   # Spread read refreshes across time
+  write_delay_ms = 250  # More conservative on writes
+}
+```
+
+> **Note:** Delays slow down plan and apply times proportionally. A `read_delay_ms`
+> of 50 ms with 1,000 repositories adds ~50 seconds to every plan. Balance delay
+> against your CI timeout budget.
+
+## Repository Partitioning
+
+Partitioning lets you scope a Terraform plan to a subset of repositories, reducing
+API consumption in proportion to the fraction of repos in the partition.
+
+### Directory Layout
+
+Organise your repository config files into subdirectories under `config/repository/`.
+Each subdirectory is a named partition:
+
+```text
+config/repository/
+├── common.yml          # Always loaded (not a partition)
+├── infra/
+│   ├── ci-tooling.yml
+│   └── platform-services.yml
+├── product/
+│   ├── frontend.yml
+│   └── backend.yml
+└── legacy/
+    └── old-services.yml
+```
+
+Top-level `*.yml` files (like `common.yml`) are **always** loaded regardless of
+which partitions are selected.
+
+### Selecting Partitions
+
+Pass the `repository_partitions` variable to the module. An empty list (the
+default) loads all partitions — identical to the pre-partitioning behaviour.
+
+```hcl
+module "github_org" {
+  source  = "gjed/config-as-yaml/github"
+  version = "~> 1.0"
+
+  config_path = "${path.root}/config"
+
+  # Load only the infra and product partitions
+  repository_partitions = ["infra", "product"]
+}
+```
+
+Setting `repository_partitions = []` (or omitting it) loads everything.
+
+> **⚠️ Warning — Partition switching causes destroy plans**
+>
+> When you change `repository_partitions` from `[]` (all repos) to `["infra"]`,
+> repositories in other partitions (`product`, `legacy`) disappear from
+> Terraform's view. Terraform will plan to **destroy** their resources.
+>
+> Always verify the plan output before applying when narrowing the partition
+> selection. Use repository deletion protection (see issue #37) as a safety net.
+> The `detect-partitions.sh` script is designed to help CI avoid accidental
+> partition narrowing.
+
+### CI Integration with `detect-partitions.sh`
+
+The `scripts/detect-partitions.sh` helper maps git changes to the affected
+partitions, so CI only plans the partitions that actually changed.
+
+**Basic usage:**
+
+```bash
+# Show which partitions changed between main and the current branch
+./scripts/detect-partitions.sh main...HEAD
+
+# Output as a JSON array for use as a Terraform variable
+./scripts/detect-partitions.sh --tfvar main...HEAD
+```
+
+**GitHub Actions example:**
+
+```yaml
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      partitions: ${{ steps.detect.outputs.partitions }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for git diff across branches
+
+      - name: Detect affected partitions
+        id: detect
+        run: |
+          partitions=$(./scripts/detect-partitions.sh --tfvar main...HEAD)
+          echo "partitions=$partitions" >> "$GITHUB_OUTPUT"
+
+  plan:
+    needs: detect
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Terraform plan (scoped to affected partitions)
+        env:
+          TF_VAR_repository_partitions: ${{ needs.detect.outputs.partitions }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          terraform init
+          terraform plan
+```
+
+**Escalation rules:**
+
+| Changed files | Partitions planned |
+|---|---|
+| `config/group/*.yml` | All partitions |
+| `config/ruleset/*.yml` | All partitions |
+| `config/webhook/*.yml` | All partitions |
+| `config/config.yml` | All partitions |
+| `config/repository/<partition>/*.yml` | Only the changed partitions |
+| `config/repository/*.yml` (top-level) | None (always loaded) |
+| Non-config files only | None |
+
+Shared config (groups, rulesets, webhooks, `config.yml`) can affect any
+repository, so changes there require planning all partitions.

--- a/examples/consumer/main.tf
+++ b/examples/consumer/main.tf
@@ -39,6 +39,31 @@ module "github_org" {
   # Must be a static string — computed values are not supported.
   config_path = "${path.root}/config"
 
+  # Optional: scope the plan to specific repository partitions (subdirectories
+  # under config/repository/). Useful for large organisations that exceed GitHub
+  # API rate limits on a full plan.
+  #
+  # Example directory layout:
+  #   config/repository/
+  #   ├── common.yml          # Always loaded (top-level, not a partition)
+  #   ├── infra/              # Partition "infra"
+  #   │   └── services.yml
+  #   └── product/            # Partition "product"
+  #       └── apps.yml
+  #
+  # Load only the "infra" partition (common.yml is still always loaded):
+  #   repository_partitions = ["infra"]
+  #
+  # Default (empty list) loads all partitions — identical to pre-partitioning
+  # behaviour. No migration needed for flat config/repository/ layouts.
+  #
+  # ⚠️  WARNING: Narrowing the partition list causes repositories outside the
+  # selected partitions to disappear from Terraform's view, resulting in a
+  # planned destroy for their resources. Always review the plan carefully before
+  # applying when changing repository_partitions. See docs/scaling.md for details.
+  #
+  # repository_partitions = []  # default: all partitions
+
   # Optional: pass webhook secrets via environment variables or a secrets manager.
   # webhook_secrets = {
   #   MY_WEBHOOK_SECRET = var.my_webhook_secret

--- a/openspec/changes/api-rate-limit-mitigation/tasks.md
+++ b/openspec/changes/api-rate-limit-mitigation/tasks.md
@@ -1,45 +1,45 @@
 ## 1. Module interface
 
-- [ ] 1.1 Add `repository_partitions` variable to `variables.tf` with type `list(string)`, default `[]`, and description
-- [ ] 1.2 Run `terraform fmt` and `terraform validate` to confirm syntax
+- [x] 1.1 Add `repository_partitions` variable to `variables.tf` with type `list(string)`, default `[]`, and description
+- [x] 1.2 Run `terraform fmt` and `terraform validate` to confirm syntax
 
 ## 2. Partition-aware file loading
 
-- [ ] 2.1 Add `repository_partition_dirs` local to discover subdirectories under `config/repository/`
-- [ ] 2.2 Add `active_partitions` local that resolves empty list to all discovered partitions
-- [ ] 2.3 Replace `repository_files` local with partition-aware loading (top-level `*.yml` always + active partition `*.yml`)
-- [ ] 2.4 Add `check "valid_partitions"` block to validate requested partition names exist as directories
-- [ ] 2.5 Verify duplicate detection still works across partition files (filenames include partition prefix)
-- [ ] 2.6 Run `terraform validate` with the example consumer config to confirm backward compatibility
+- [x] 2.1 Add `repository_partition_dirs` local to discover subdirectories under `config/repository/`
+- [x] 2.2 Add `active_partitions` local that resolves empty list to all discovered partitions
+- [x] 2.3 Replace `repository_files` local with partition-aware loading (top-level `*.yml` always + active partition `*.yml`)
+- [x] 2.4 Add `check "valid_partitions"` block to validate requested partition names exist as directories
+- [x] 2.5 Verify duplicate detection still works across partition files (filenames include partition prefix)
+- [x] 2.6 Run `terraform validate` with the example consumer config to confirm backward compatibility
 
 ## 3. Partition detection script
 
-- [ ] 3.1 Create `scripts/detect-partitions.sh` with git diff range argument parsing
-- [ ] 3.2 Implement shared config detection (group/, ruleset/, webhook/, config.yml → all partitions)
-- [ ] 3.3 Implement top-level repo file detection (config/repository/*.yml → no partitions)
-- [ ] 3.4 Implement partition-specific detection (config/repository/<partition>/ → those partitions only)
-- [ ] 3.5 Implement escalation logic (shared config overrides partition-specific)
-- [ ] 3.6 Add `--tfvar` flag for JSON array output format
-- [ ] 3.7 Handle no-config-changes case (empty output, exit 0)
-- [ ] 3.8 Make script executable and add usage help (`--help`)
+- [x] 3.1 Create `scripts/detect-partitions.sh` with git diff range argument parsing
+- [x] 3.2 Implement shared config detection (group/, ruleset/, webhook/, config.yml → all partitions)
+- [x] 3.3 Implement top-level repo file detection (config/repository/*.yml → no partitions)
+- [x] 3.4 Implement partition-specific detection (config/repository/<partition>/ → those partitions only)
+- [x] 3.5 Implement escalation logic (shared config overrides partition-specific)
+- [x] 3.6 Add `--tfvar` flag for JSON array output format
+- [x] 3.7 Handle no-config-changes case (empty output, exit 0)
+- [x] 3.8 Make script executable and add usage help (`--help`)
 
 ## 4. Scaling documentation
 
-- [ ] 4.1 Create `docs/scaling.md` with resource-per-repository API cost table
-- [ ] 4.2 Add rate limit threshold table (100/500/1000/2000 repos vs PAT/App limits)
-- [ ] 4.3 Add provider tuning recommendations by org size (read_delay_ms, write_delay_ms)
-- [ ] 4.4 Add partitioning strategy section with directory layout example
-- [ ] 4.5 Add CI integration example showing `detect-partitions.sh` + `terraform plan` pipeline
-- [ ] 4.6 Add warning about partition switching causing destroy plans for repos outside the selected partitions
+- [x] 4.1 Create `docs/scaling.md` with resource-per-repository API cost table
+- [x] 4.2 Add rate limit threshold table (100/500/1000/2000 repos vs PAT/App limits)
+- [x] 4.3 Add provider tuning recommendations by org size (read_delay_ms, write_delay_ms)
+- [x] 4.4 Add partitioning strategy section with directory layout example
+- [x] 4.5 Add CI integration example showing `detect-partitions.sh` + `terraform plan` pipeline
+- [x] 4.6 Add warning about partition switching causing destroy plans for repos outside the selected partitions
 
 ## 5. Consumer example update
 
-- [ ] 5.1 Update `examples/consumer/main.tf` to document `repository_partitions` usage in comments
-- [ ] 5.2 Add partition warning comment about repos dropping out of scope when filtering
+- [x] 5.1 Update `examples/consumer/main.tf` to document `repository_partitions` usage in comments
+- [x] 5.2 Add partition warning comment about repos dropping out of scope when filtering
 
 ## 6. Validation
 
-- [ ] 6.1 Run `terraform fmt` on all changed `.tf` files
-- [ ] 6.2 Run `terraform validate` with default (empty) partitions to confirm backward compatibility
-- [ ] 6.3 Run `pre-commit run --all-files` to catch linting issues
-- [ ] 6.4 Test `detect-partitions.sh` manually against a sample git diff
+- [x] 6.1 Run `terraform fmt` on all changed `.tf` files
+- [x] 6.2 Run `terraform validate` with default (empty) partitions to confirm backward compatibility
+- [x] 6.3 Run `pre-commit run --all-files` to catch linting issues
+- [x] 6.4 Test `detect-partitions.sh` manually against a sample git diff

--- a/scripts/detect-partitions.sh
+++ b/scripts/detect-partitions.sh
@@ -6,19 +6,22 @@
 #
 # Arguments:
 #   <git-diff-range>  Git rev range passed to git diff --name-only (e.g. main...HEAD).
-#                     Defaults to HEAD (staged + unstaged changes against HEAD).
+#                     Defaults to HEAD (tracked file changes vs HEAD).
 #
 # Flags:
 #   --tfvar   Output as a JSON array (e.g. ["infra","platform"]) instead of one-per-line.
+#             Requires jq. Empty output becomes "[]".
 #   --help    Show this help message and exit.
 #
 # Exit codes:
 #   0  Success (including "no config changes" case — empty output signals no plan needed).
-#   1  Error (e.g. git command failed).
+#   1  Error (e.g. git command failed, jq not found).
 #
 # Assumptions:
 #   - Repository config files live under config/repository/
 #   - Partition subdirectories are one level deep: config/repository/<partition>/*.yml
+#   - Only directories containing at least one *.yml file are considered partitions
+#     (matches Terraform's repository_partition_dirs discovery logic)
 #   - Shared config directories: config/group/, config/ruleset/, config/webhook/, config/config.yml
 #   - This script is run from the repository root.
 #
@@ -57,6 +60,11 @@ for arg in "$@"; do
   esac
 done
 
+if [[ "$TFVAR" == true ]] && ! command -v jq &>/dev/null; then
+  echo "Error: --tfvar requires jq. Install it (e.g. apt install jq / brew install jq)." >&2
+  exit 1
+fi
+
 # ---------------------------------------------------------------------------
 # Collect changed files
 # ---------------------------------------------------------------------------
@@ -67,12 +75,28 @@ if [[ -n "$DIFF_RANGE" ]]; then
     exit 1
   }
 else
-  # Default: uncommitted changes (staged + unstaged) against HEAD
+  # Default: tracked file changes vs HEAD (does not include untracked files)
   changed_files=$(git diff --name-only HEAD 2>/dev/null) || {
     echo "Error: git diff failed" >&2
     exit 1
   }
 fi
+
+# ---------------------------------------------------------------------------
+# Discover known partitions (dirs containing at least one *.yml — matches
+# Terraform's repository_partition_dirs logic which uses fileset("*/*.yml"))
+# ---------------------------------------------------------------------------
+
+repo_config_dir="config/repository"
+if [[ ! -d "$repo_config_dir" ]]; then
+  echo "Error: directory '$repo_config_dir' not found. Run from the repository root." >&2
+  exit 1
+fi
+
+known_partitions=$(find "$repo_config_dir" -mindepth 2 -maxdepth 2 -name "*.yml" \
+  | sed "s|^$repo_config_dir/||" \
+  | cut -d/ -f1 \
+  | sort -u)
 
 # ---------------------------------------------------------------------------
 # Classify changed files
@@ -108,15 +132,8 @@ done <<< "$changed_files"
 # ---------------------------------------------------------------------------
 
 if [[ "$shared_change" == true ]]; then
-  # Output all known partitions (discover from filesystem)
-  repo_config_dir="config/repository"
-  if [[ ! -d "$repo_config_dir" ]]; then
-    echo "Error: directory '$repo_config_dir' not found. Run from the repository root." >&2
-    exit 1
-  fi
-  result=$(find "$repo_config_dir" -mindepth 1 -maxdepth 1 -type d -print0 \
-    | sort -z \
-    | xargs -0 -I{} basename {})
+  # All known partitions (only dirs with *.yml, matching Terraform's discovery)
+  result="$known_partitions"
 elif [[ -n "$partition_list" ]]; then
   # Deduplicate and sort
   result=$(echo "$partition_list" | sort -u | grep -v '^$')
@@ -130,24 +147,11 @@ fi
 # ---------------------------------------------------------------------------
 
 if [[ "$TFVAR" == true ]]; then
-  # JSON array format for use as TF_VAR_repository_partitions
+  # JSON array via jq — handles any characters in partition names correctly
   if [[ -z "$result" ]]; then
     echo "[]"
   else
-    # Build JSON array from newline-separated list
-    json="["
-    first=true
-    while IFS= read -r item; do
-      [[ -z "$item" ]] && continue
-      if [[ "$first" == true ]]; then
-        json="${json}\"${item}\""
-        first=false
-      else
-        json="${json},\"${item}\""
-      fi
-    done <<< "$result"
-    json="${json}]"
-    echo "$json"
+    echo "$result" | jq -R -s -c 'split("\n") | map(select(length > 0))'
   fi
 else
   # One partition per line

--- a/scripts/detect-partitions.sh
+++ b/scripts/detect-partitions.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# detect-partitions.sh — Map git diff output to affected Terraform partitions.
+#
+# Usage:
+#   ./scripts/detect-partitions.sh [--tfvar] [--help] [<git-diff-range>]
+#
+# Arguments:
+#   <git-diff-range>  Git rev range passed to git diff --name-only (e.g. main...HEAD).
+#                     Defaults to HEAD (staged + unstaged changes against HEAD).
+#
+# Flags:
+#   --tfvar   Output as a JSON array (e.g. ["infra","platform"]) instead of one-per-line.
+#   --help    Show this help message and exit.
+#
+# Exit codes:
+#   0  Success (including "no config changes" case — empty output signals no plan needed).
+#   1  Error (e.g. git command failed).
+#
+# Assumptions:
+#   - Repository config files live under config/repository/
+#   - Partition subdirectories are one level deep: config/repository/<partition>/*.yml
+#   - Shared config directories: config/group/, config/ruleset/, config/webhook/, config/config.yml
+#   - This script is run from the repository root.
+#
+# Escalation rules:
+#   1. Shared config changes  → output ALL partition names (any repo may be affected)
+#   2. Partition-specific     → output only the changed partitions
+#   3. Top-level repo files   → no partitions (always loaded, no partition plan needed)
+#   4. No config changes      → empty output, exit 0
+
+set -eo pipefail
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+TFVAR=false
+DIFF_RANGE=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h)
+      sed -n '2,/^$/p' "$0" | grep '^#' | sed 's/^# \?//'
+      exit 0
+      ;;
+    --tfvar)
+      TFVAR=true
+      ;;
+    -*)
+      echo "Unknown flag: $arg" >&2
+      echo "Run with --help for usage." >&2
+      exit 1
+      ;;
+    *)
+      DIFF_RANGE="$arg"
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Collect changed files
+# ---------------------------------------------------------------------------
+
+if [[ -n "$DIFF_RANGE" ]]; then
+  changed_files=$(git diff --name-only "$DIFF_RANGE" 2>/dev/null) || {
+    echo "Error: git diff failed for range '$DIFF_RANGE'" >&2
+    exit 1
+  }
+else
+  # Default: uncommitted changes (staged + unstaged) against HEAD
+  changed_files=$(git diff --name-only HEAD 2>/dev/null) || {
+    echo "Error: git diff failed" >&2
+    exit 1
+  }
+fi
+
+# ---------------------------------------------------------------------------
+# Classify changed files
+# ---------------------------------------------------------------------------
+
+shared_change=false
+partition_list=""  # newline-separated partition names
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  # Shared config: any change here requires planning all partitions
+  if [[ "$file" == config/config.yml ]] \
+      || [[ "$file" == config/group/* ]] \
+      || [[ "$file" == config/ruleset/* ]] \
+      || [[ "$file" == config/webhook/* ]]; then
+    shared_change=true
+
+  # Partition-specific repo file: config/repository/<partition>/<file>.yml
+  elif [[ "$file" =~ ^config/repository/([^/]+)/[^/]+\.yml$ ]]; then
+    partition="${BASH_REMATCH[1]}"
+    partition_list="${partition_list}${partition}"$'\n'
+
+  # Top-level repo file: config/repository/<file>.yml — always loaded, no partition needed
+  elif [[ "$file" =~ ^config/repository/[^/]+\.yml$ ]]; then
+    : # no-op
+
+  fi
+done <<< "$changed_files"
+
+# ---------------------------------------------------------------------------
+# Apply escalation: shared config overrides partition-specific
+# ---------------------------------------------------------------------------
+
+if [[ "$shared_change" == true ]]; then
+  # Output all known partitions (discover from filesystem)
+  repo_config_dir="config/repository"
+  if [[ ! -d "$repo_config_dir" ]]; then
+    echo "Error: directory '$repo_config_dir' not found. Run from the repository root." >&2
+    exit 1
+  fi
+  result=$(find "$repo_config_dir" -mindepth 1 -maxdepth 1 -type d -print0 \
+    | sort -z \
+    | xargs -0 -I{} basename {})
+elif [[ -n "$partition_list" ]]; then
+  # Deduplicate and sort
+  result=$(echo "$partition_list" | sort -u | grep -v '^$')
+else
+  # No config changes that require a partition plan
+  result=""
+fi
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+if [[ "$TFVAR" == true ]]; then
+  # JSON array format for use as TF_VAR_repository_partitions
+  if [[ -z "$result" ]]; then
+    echo "[]"
+  else
+    # Build JSON array from newline-separated list
+    json="["
+    first=true
+    while IFS= read -r item; do
+      [[ -z "$item" ]] && continue
+      if [[ "$first" == true ]]; then
+        json="${json}\"${item}\""
+        first=false
+      else
+        json="${json},\"${item}\""
+      fi
+    done <<< "$result"
+    json="${json}]"
+    echo "$json"
+  fi
+else
+  # One partition per line
+  if [[ -n "$result" ]]; then
+    echo "$result"
+  fi
+fi

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,12 @@ variable "config_path" {
   type        = string
 }
 
+variable "repository_partitions" {
+  description = "List of partition names (subdirectories under config/repository/) to load. An empty list loads all partitions. Top-level *.yml files in config/repository/ are always loaded regardless of this setting."
+  type        = list(string)
+  default     = []
+}
+
 variable "webhook_secrets" {
   description = "Map of webhook secret names to their values. Keys should match the VAR_NAME in env:VAR_NAME patterns used in webhook configurations."
   type        = map(string)

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -25,7 +25,7 @@ locals {
   repository_files = toset(concat(
     tolist(fileset(local.repository_config_path, "*.yml")),
     flatten([
-      for partition in local.active_partitions :
+      for partition in setintersection(local.active_partitions, local.repository_partition_dirs) :
       [for f in fileset("${local.repository_config_path}/${partition}", "*.yml") : "${partition}/${f}"]
     ])
   ))

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -9,11 +9,29 @@ locals {
   # Read common config (single file - not splittable)
   common_config = yamldecode(file("${local.config_base_path}/config.yml"))
 
-  # Helper: Load and merge all YAML files from a directory
-  # Files are sorted alphabetically - later files override earlier ones for duplicate keys
-  repository_files = fileset(local.repository_config_path, "*.yml")
-  group_files      = fileset(local.group_config_path, "*.yml")
-  ruleset_files    = fileset(local.ruleset_config_path, "*.yml")
+  # Discover partition subdirectories under config/repository/
+  # Each immediate subdirectory is a named partition
+  repository_partition_dirs = toset([
+    for f in fileset(local.repository_config_path, "*/*.yml") :
+    split("/", f)[0]
+  ])
+
+  # Resolve active partitions: empty list means all discovered partitions
+  active_partitions = length(var.repository_partitions) == 0 ? local.repository_partition_dirs : toset(var.repository_partitions)
+
+  # Partition-aware repository file collection:
+  # - Top-level *.yml files are always loaded (no path prefix)
+  # - Active partition files are loaded with "<partition>/" prefix so file paths are unique
+  repository_files = toset(concat(
+    tolist(fileset(local.repository_config_path, "*.yml")),
+    flatten([
+      for partition in local.active_partitions :
+      [for f in fileset("${local.repository_config_path}/${partition}", "*.yml") : "${partition}/${f}"]
+    ])
+  ))
+
+  group_files   = fileset(local.group_config_path, "*.yml")
+  ruleset_files = fileset(local.ruleset_config_path, "*.yml")
 
   # Load individual YAML files (for duplicate detection)
   repository_configs_by_file = {
@@ -63,6 +81,12 @@ locals {
       file if config != null && contains(keys(config), key)
     ]
   }
+
+  # Validate requested partition names against discovered directories
+  invalid_partition_names = [
+    for p in var.repository_partitions :
+    p if !contains(tolist(local.repository_partition_dirs), p)
+  ]
 
   # Filter to only duplicates (appearing in more than one file)
   duplicate_repository_keys = {
@@ -788,6 +812,14 @@ check "team_nesting_depth" {
       ])
     ])) == 0
     error_message = "Team nesting exceeds maximum depth of 3 levels. Reorganize your team hierarchy."
+  }
+}
+
+# Validate that all requested partition names correspond to existing subdirectories
+check "valid_partitions" {
+  assert {
+    condition     = length(local.invalid_partition_names) == 0
+    error_message = "Invalid partition name(s): ${join(", ", local.invalid_partition_names)}. Available partitions: ${join(", ", sort(tolist(local.repository_partition_dirs)))}. Check config/repository/ for valid subdirectory names."
   }
 }
 


### PR DESCRIPTION
## Summary

Adds repository partitioning to scope \`terraform plan\` to a subset of repositories, reducing GitHub API consumption for large organisations that hit rate limits.

Closes #36

## Problem

At 700+ repos with PAT auth (5,000 req/hr limit), a single plan exhausts the rate limit (~7 API calls/repo). There was no way to scope operations to a subset without error-prone \`-target\` flags.

## Changes

### \`variables.tf\`
- New \`repository_partitions\` variable (\`list(string)\`, default \`[]\`) — backward-compatible, empty list loads everything as before

### \`yaml-config.tf\`
- \`repository_partition_dirs\` — discovers subdirectories under \`config/repository/\`
- \`active_partitions\` — resolves empty list to all discovered partitions
- \`repository_files\` — now loads top-level \`*.yml\` always + active partition files (with \`<partition>/\` path prefix so cross-partition duplicate detection works)
- \`check "valid_partitions"\` — warns at plan time if a requested partition name doesn't exist

### \`scripts/detect-partitions.sh\` (new)
CI helper that maps \`git diff\` output to affected partition names:
- Shared config changes (\`config/group/\`, \`config/ruleset/\`, \`config/webhook/\`, \`config/config.yml\`) → all partitions
- Partition-specific changes (\`config/repository/<partition>/\`) → only those partitions
- Top-level repo files → no partitions (always loaded anyway)
- \`--tfvar\` flag for JSON array output (\`["infra","platform"]\`)

### \`docs/scaling.md\` (new)
- Per-resource API cost table
- Rate limit thresholds for 100–2000 repos (PAT vs GitHub App)
- Provider tuning recommendations by org size
- Partitioning strategy with directory layout example and GitHub Actions CI integration
- Warning about destroy plans when narrowing partition selection

### \`examples/consumer/main.tf\`
- Comments documenting \`repository_partitions\` usage and the destroy-plan warning

## How to Use

**Partition your config:**
\`\`\`
config/repository/
├── common.yml        # always loaded
├── infra/
│   └── services.yml
└── product/
    └── apps.yml
\`\`\`

**Scope a plan:**
\`\`\`hcl
module "github_org" {
  source                = "gjed/config-as-yaml/github"
  config_path           = "\${path.root}/config"
  repository_partitions = ["infra"]
}
\`\`\`

**CI integration:**
\`\`\`bash
partitions=\$(./scripts/detect-partitions.sh --tfvar main...HEAD)
TF_VAR_repository_partitions="\$partitions" terraform plan
\`\`\`

## Backward Compatibility

No breaking changes. \`repository_partitions = []\` (default) is identical to current behaviour. Flat \`config/repository/\` layouts with no subdirectories work unchanged.