### PR TITLE
feat(membership): add organization membership management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ terraform-github-config-as-yaml/
 │   ├── config.yml                    # Organization and global settings
 │   ├── group/                        # Configuration groups (oss, internal, etc.)
 │   ├── repository/                   # Repository definitions
-│   └── ruleset/                      # Ruleset definitions
+│   ├── ruleset/                      # Ruleset definitions
+│   └── membership/                   # Organization membership definitions (optional)
 ├── examples/consumer/                # Consumer example for module usage
 ├── scripts/
 │   ├── validate-config.py            # Validates configuration files
@@ -144,6 +145,46 @@ subscription: free  # Options: free, pro, team, enterprise
 
 If you configure rulesets for private repos on the free tier, they will be
 automatically skipped (with a warning in the validation script output).
+
+### Adding/managing organization members
+
+> ⚠️ **High-risk feature.** Read all warnings before enabling.
+
+Organization membership is managed via YAML files in `config/membership/`. Each file maps GitHub
+usernames to their role (`member` or `admin`).
+
+**SCIM/SSO conflict warning:** Do **NOT** enable membership management if your organization uses
+SCIM or an IdP (Okta, Azure AD, GitHub Enterprise SCIM) for provisioning. Terraform and SCIM will
+conflict and cause unpredictable membership changes.
+
+1. Create or edit files in `config/membership/` with the format:
+
+   ```yaml
+   # config/membership/engineering.yml
+   alice: member
+   bob: member
+   carol: admin
+   ```
+
+1. Enable membership management in your module call:
+
+   ```hcl
+   module "github_org" {
+     source = "gjed/config-as-yaml/github"
+     # ...
+     membership_management_enabled = true
+   }
+   ```
+
+1. Run `terraform plan` — carefully review any removals before applying
+1. Run `terraform apply`
+
+**Removing a member:** Delete their username from the YAML. On the next apply, Terraform will
+remove them from the organization, revoking all private repo access and destroying private forks.
+Always review `terraform plan` output before applying.
+
+Only effective for organizations (`is_organization: true` in `config/config.yml`).
+Has no effect on personal accounts.
 
 ### Importing existing repositories
 

--- a/config/membership/example-members.yml
+++ b/config/membership/example-members.yml
@@ -1,0 +1,33 @@
+# Organization membership configuration
+#
+# Format: map of GitHub username → role
+# Valid roles: "member" (org member), "admin" (org owner)
+#
+# ⚠️  BEFORE ENABLING membership management, read the warnings below:
+#
+#   1. DESTRUCTIVE OPERATIONS: Removing a username from this file will remove
+#      that person from the GitHub organization on the next `terraform apply`.
+#      This revokes access to ALL private repositories and destroys private forks.
+#      Always run `terraform plan` and review before applying.
+#
+#   2. SCIM/SSO CONFLICT: Do NOT use this if your organization uses SCIM or an
+#      IdP (Okta, Azure AD, GitHub Enterprise SCIM) for membership provisioning.
+#      Terraform and SCIM will conflict and cause unpredictable membership changes.
+#
+#   3. OPT-IN REQUIRED: Membership management is disabled by default. Enable it
+#      by setting `membership_management_enabled = true` in your module call.
+#
+# Example:
+#
+# alice: member
+# bob: member
+# carol: admin
+#
+# To use this file:
+#   1. Uncomment and populate the entries below
+#   2. Set membership_management_enabled = true in your module call
+#   3. Run terraform plan to preview, then terraform apply
+
+# alice: member
+# bob: member
+# carol: admin

--- a/examples/consumer/main.tf
+++ b/examples/consumer/main.tf
@@ -68,4 +68,14 @@ module "github_org" {
   # webhook_secrets = {
   #   MY_WEBHOOK_SECRET = var.my_webhook_secret
   # }
+
+  # Optional: enable organization membership management via config/membership/.
+  #
+  # WARNING: When enabled, removing a username from config/membership/ will remove that person
+  # from the GitHub organization on the next terraform apply, revoking all private repo access
+  # and destroying private forks. Always run terraform plan and review before applying.
+  #
+  # WARNING: Do NOT enable alongside SCIM/IdP provisioning (Okta, Azure AD, SCIM) — they conflict.
+  #
+  # membership_management_enabled = true
 }

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,13 @@ resource "github_membership" "this" {
 
   username = each.key
   role     = each.value
+
+  lifecycle {
+    precondition {
+      condition     = contains(["member", "admin"], each.value)
+      error_message = "Invalid role '${each.value}' for member '${each.key}'. Valid roles: member, admin."
+    }
+  }
 }
 
 # Organization-level Actions permissions

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,17 @@ module "repositories" {
 
 }
 
+# Organization membership management
+# Only managed when membership_management_enabled = true AND target is an organization
+# WARNING: Removing a username from config/membership/ will remove them from the org on apply
+# WARNING: Do NOT use alongside SCIM/IdP provisioning — they will conflict
+resource "github_membership" "this" {
+  for_each = local.effective_membership
+
+  username = each.key
+  role     = each.value
+}
+
 # Organization-level Actions permissions
 # Only created when actions configuration is specified in config.yml
 resource "github_actions_organization_permissions" "this" {

--- a/openspec/changes/add-org-membership/tasks.md
+++ b/openspec/changes/add-org-membership/tasks.md
@@ -2,47 +2,47 @@
 
 ## 1. YAML Parsing for Membership
 
-- [ ] 1.1 Add membership directory loading in `yaml-config.tf` — add `membership_config_path`, `membership_files`, `membership_configs_by_file`, and `membership_config` locals following the existing pattern for `repository/`, `group/`, `ruleset/`, and `webhook/`. The directory MUST be optional (use `try()` like `webhook_files`).
-- [ ] 1.2 Add duplicate membership key detection — add `membership_key_occurrences` and `duplicate_membership_keys` locals following the existing `repo_key_occurrences`/`duplicate_repository_keys` pattern.
-- [ ] 1.3 Add `effective_membership` local that returns `{}` when `var.membership_management_enabled` is `false` OR `local.is_organization` is `false`, and returns `local.membership_config` otherwise.
+- [x] 1.1 Add membership directory loading in `yaml-config.tf` — add `membership_config_path`, `membership_files`, `membership_configs_by_file`, and `membership_config` locals following the existing pattern for `repository/`, `group/`, `ruleset/`, and `webhook/`. The directory MUST be optional (use `try()` like `webhook_files`).
+- [x] 1.2 Add duplicate membership key detection — add `membership_key_occurrences` and `duplicate_membership_keys` locals following the existing `repo_key_occurrences`/`duplicate_repository_keys` pattern.
+- [x] 1.3 Add `effective_membership` local that returns `{}` when `var.membership_management_enabled` is `false` OR `local.is_organization` is `false`, and returns `local.membership_config` otherwise.
 
 ## 2. Module Variables
 
-- [ ] 2.1 Add `membership_management_enabled` variable to `variables.tf` — boolean, default `false`, with description explaining the safety implications and SCIM/SSO conflict warning.
+- [x] 2.1 Add `membership_management_enabled` variable to `variables.tf` — boolean, default `false`, with description explaining the safety implications and SCIM/SSO conflict warning.
 
 ## 3. Membership Resource
 
-- [ ] 3.1 Add `github_membership` resource in `main.tf` — use `for_each` over `local.effective_membership`. Each entry maps `username` (key) and `role` (value). Place after the existing org-level resources.
+- [x] 3.1 Add `github_membership` resource in `main.tf` — use `for_each` over `local.effective_membership`. Each entry maps `username` (key) and `role` (value). Place after the existing org-level resources.
 
 ## 4. Module Outputs
 
-- [ ] 4.1 Add `managed_members` output to `outputs.tf` — map of managed members with username and role, sourced from `github_membership` resources.
-- [ ] 4.2 Add `managed_member_count` output to `outputs.tf` — count of managed members.
-- [ ] 4.3 Update `duplicate_key_warnings` output to include membership duplicate warnings.
+- [x] 4.1 Add `managed_members` output to `outputs.tf` — map of managed members with username and role, sourced from `github_membership` resources.
+- [x] 4.2 Add `managed_member_count` output to `outputs.tf` — count of managed members.
+- [x] 4.3 Update `duplicate_key_warnings` output to include membership duplicate warnings.
 
 ## 5. Template Configuration
 
-- [ ] 5.1 Create `config/membership/` directory with a commented-out example file (`example-members.yml`) showing the `username: role` format and documenting valid roles (`member`, `admin`).
+- [x] 5.1 Create `config/membership/` directory with a commented-out example file (`example-members.yml`) showing the `username: role` format and documenting valid roles (`member`, `admin`).
 
 ## 6. Validation Script
 
-- [ ] 6.1 Update `scripts/validate-config.py` to validate membership configuration — check that the `membership/` directory (if present) contains valid YAML with string keys and values of `member` or `admin` only. Print a SCIM/SSO reminder when membership config is present.
+- [x] 6.1 Update `scripts/validate-config.py` to validate membership configuration — check that the `membership/` directory (if present) contains valid YAML with string keys and values of `member` or `admin` only. Print a SCIM/SSO reminder when membership config is present.
 
 ## 7. Documentation
 
-- [ ] 7.1 Update `AGENTS.md` — add "Adding/managing organization members" section under Common Tasks, document `config/membership/` directory in Project Structure, and add SCIM/SSO conflict warning.
-- [ ] 7.2 Update `examples/consumer/` — add `membership_management_enabled = true` (commented out) to the consumer example with inline documentation.
+- [x] 7.1 Update `AGENTS.md` — add "Adding/managing organization members" section under Common Tasks, document `config/membership/` directory in Project Structure, and add SCIM/SSO conflict warning.
+- [x] 7.2 Update `examples/consumer/` — add `membership_management_enabled = true` (commented out) to the consumer example with inline documentation.
 
 ## 8. Spec Updates
 
-- [ ] 8.1 Create spec delta at `openspec/changes/add-org-membership/specs/org-membership/spec.md` (done — verify with `openspec validate`).
-- [ ] 8.2 Create spec delta at `openspec/changes/add-org-membership/specs/module-interface/spec.md` (done — verify with `openspec validate`).
-- [ ] 8.3 Create spec delta at `openspec/changes/add-org-membership/specs/repository-management/spec.md` (done — verify with `openspec validate`).
+- [x] 8.1 Create spec delta at `openspec/changes/add-org-membership/specs/org-membership/spec.md` (done — verify with `openspec validate`).
+- [x] 8.2 Create spec delta at `openspec/changes/add-org-membership/specs/module-interface/spec.md` (done — verify with `openspec validate`).
+- [x] 8.3 Create spec delta at `openspec/changes/add-org-membership/specs/repository-management/spec.md` (done — verify with `openspec validate`).
 
 ## 9. Verification
 
-- [ ] 9.1 Run `terraform validate` with membership config present and `membership_management_enabled = true`.
-- [ ] 9.2 Run `terraform validate` with membership config present and `membership_management_enabled = false` (default) — confirm no membership resources in plan.
-- [ ] 9.3 Run `terraform validate` with membership directory missing — confirm no errors.
-- [ ] 9.4 Run `scripts/validate-config.py` — confirm membership validation works.
-- [ ] 9.5 Run `pre-commit run --all-files` — confirm no formatting or linting issues.
+- [x] 9.1 Run `terraform validate` with membership config present and `membership_management_enabled = true`.
+- [x] 9.2 Run `terraform validate` with membership config present and `membership_management_enabled = false` (default) — confirm no membership resources in plan.
+- [x] 9.3 Run `terraform validate` with membership directory missing — confirm no errors.
+- [x] 9.4 Run `scripts/validate-config.py` — confirm membership validation works.
+- [x] 9.5 Run `pre-commit run --all-files` — confirm no formatting or linting issues.

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,6 +37,22 @@ output "subscription_warnings" {
   } : null
 }
 
+output "managed_members" {
+  description = "Map of organization members managed by Terraform, keyed by username with their role"
+  value = {
+    for username, membership in github_membership.this :
+    username => {
+      username = membership.username
+      role     = membership.role
+    }
+  }
+}
+
+output "managed_member_count" {
+  description = "Total number of organization members managed by Terraform"
+  value       = length(github_membership.this)
+}
+
 # Output warning when duplicate keys are detected across config files
 # Duplicates cause shallow merge - the entire definition from the later file wins
 output "duplicate_key_warnings" {
@@ -44,7 +60,8 @@ output "duplicate_key_warnings" {
   value = (
     length(local.duplicate_repository_keys) > 0 ||
     length(local.duplicate_group_keys) > 0 ||
-    length(local.duplicate_ruleset_keys) > 0
+    length(local.duplicate_ruleset_keys) > 0 ||
+    length(local.duplicate_membership_keys) > 0
     ) ? {
     message = "WARNING: Duplicate keys detected across config files. Later files (alphabetically) completely override earlier ones - no deep merge!"
     repositories = length(local.duplicate_repository_keys) > 0 ? {
@@ -57,6 +74,10 @@ output "duplicate_key_warnings" {
     } : null
     rulesets = length(local.duplicate_ruleset_keys) > 0 ? {
       for key, files in local.duplicate_ruleset_keys :
+      key => "defined in: ${join(", ", files)} - using: ${files[length(files) - 1]}"
+    } : null
+    members = length(local.duplicate_membership_keys) > 0 ? {
+      for key, files in local.duplicate_membership_keys :
       key => "defined in: ${join(", ", files)} - using: ${files[length(files) - 1]}"
     } : null
   } : null

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -19,8 +19,10 @@ GROUP_DIR = CONFIG_DIR / "group"
 REPOSITORY_DIR = CONFIG_DIR / "repository"
 RULESET_DIR = CONFIG_DIR / "ruleset"
 TEAM_DIR = CONFIG_DIR / "team"
+MEMBERSHIP_DIR = CONFIG_DIR / "membership"
 
 VALID_VISIBILITIES = ["public", "private", "internal"]
+VALID_MEMBERSHIP_ROLES = ["member", "admin"]
 VALID_PERMISSIONS = ["pull", "triage", "push", "maintain", "admin"]
 VALID_RULE_TYPES = [
     "deletion",
@@ -455,6 +457,28 @@ def check_team_cross_references(
             )
 
     return warnings
+def validate_membership(members: dict) -> list[str]:
+    """Validate membership configuration."""
+    errors = []
+
+    for username, role in members.items():
+        if not isinstance(username, str) or not username:
+            errors.append(
+                f"membership: Entry '{username}' has an invalid username (must be a non-empty string)"
+            )
+            continue
+
+        if not isinstance(role, str):
+            errors.append(
+                f"membership: Member '{username}' has invalid role type '{type(role).__name__}' (must be a string)"
+            )
+        elif role not in VALID_MEMBERSHIP_ROLES:
+            errors.append(
+                f"membership: Member '{username}' has invalid role '{role}' "
+                f"(valid roles: {', '.join(VALID_MEMBERSHIP_ROLES)})"
+            )
+
+    return errors
 
 
 def main():
@@ -516,6 +540,8 @@ def main():
             teams = load_team_directory(TEAM_DIR)
         else:
             teams = {}
+        # Membership directory is optional
+        members = load_yaml_directory(MEMBERSHIP_DIR) if MEMBERSHIP_DIR.exists() else {}
     except ValueError as e:
         print(f"ERROR: {e}")
         sys.exit(1)
@@ -525,6 +551,15 @@ def main():
     all_errors.extend(validate_groups(groups))
     all_errors.extend(validate_rulesets(rulesets))
     all_errors.extend(validate_repositories(repos, groups, rulesets))
+    all_errors.extend(validate_membership(members))
+
+    # Print SCIM/SSO reminder when membership config is present
+    if members:
+        print(
+            "⚠️  REMINDER: Membership config detected. Do NOT use membership management "
+            "alongside SCIM/IdP provisioning (Okta, Azure AD, GitHub Enterprise SCIM). "
+            "They will conflict and cause unpredictable membership changes.\n"
+        )
 
     # Flatten once; pass into validate_teams so it isn't re-computed internally
     flat_teams, flat_errors = flatten_teams(teams) if teams else ([], [])
@@ -569,6 +604,8 @@ def main():
             for warning in all_warnings:
                 print(f"  - {warning}")
 
+        if members:
+            print(f"  - Members: {len(members)}")
         sys.exit(0)
 
 

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -542,6 +542,14 @@ def main():
             teams = {}
         # Membership directory is optional
         members = load_yaml_directory(MEMBERSHIP_DIR) if MEMBERSHIP_DIR.exists() else {}
+        # Membership directory is optional (load_yaml_directory handles missing dir)
+        try:
+            members = load_yaml_directory(MEMBERSHIP_DIR)
+        except (TypeError, AttributeError) as e:
+            raise ValueError(
+                f"Invalid membership configuration: each YAML file in {MEMBERSHIP_DIR} "
+                "must contain a top-level mapping (username: role), not a list or scalar."
+            ) from e
     except ValueError as e:
         print(f"ERROR: {e}")
         sys.exit(1)

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,23 @@ variable "webhook_secrets" {
   default     = {}
   sensitive   = true
 }
+
+variable "membership_management_enabled" {
+  description = <<-EOT
+    Enable organization membership management via YAML configuration in config/membership/.
+
+    **Safety warning:** Defaults to false. When enabled, removing a username from config/membership/
+    will remove that person from the GitHub organization on the next `terraform apply`, which
+    revokes access to all private repositories and destroys private forks. Always run
+    `terraform plan` and review the output carefully before applying.
+
+    **SCIM/SSO conflict:** Do NOT enable this if your organization uses SCIM or an IdP for
+    membership provisioning (e.g., Okta, Azure AD, GitHub Enterprise SCIM). Terraform and SCIM
+    will conflict and cause unexpected membership changes.
+
+    Only effective when the target account is an organization (is_organization: true in config.yml).
+    Has no effect on personal accounts.
+  EOT
+  type        = bool
+  default     = false
+}

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -55,7 +55,7 @@ locals {
   }
   membership_configs_by_file = {
     for f in sort(tolist(local.membership_files)) :
-    f => try(yamldecode(file("${local.membership_config_path}/${f}")), {})
+    f => yamldecode(file("${local.membership_config_path}/${f}"))
   }
 
   # Detect duplicate keys across files
@@ -279,10 +279,13 @@ locals {
     ])
   ]))
 
-  # Load and merge membership configs from config/membership/ directory (optional)
+  # Load and merge membership configs from config/membership/ directory (optional).
+  # Derived from membership_configs_by_file to avoid re-reading files.
+  # Null entries (comment-only files) are excluded explicitly rather than via try(),
+  # so that genuinely invalid YAML still fails loudly at plan time.
   membership_config = merge([
-    for f in sort(tolist(local.membership_files)) :
-    try(yamldecode(file("${local.membership_config_path}/${f}")), {})
+    for f, config in local.membership_configs_by_file :
+    config != null ? config : {}
   ]...)
 
   # Extract values from YAML

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -5,6 +5,7 @@ locals {
   repository_config_path = "${local.config_base_path}/repository"
   group_config_path      = "${local.config_base_path}/group"
   ruleset_config_path    = "${local.config_base_path}/ruleset"
+  membership_config_path = "${local.config_base_path}/membership"
 
   # Read common config (single file - not splittable)
   common_config = yamldecode(file("${local.config_base_path}/config.yml"))
@@ -33,6 +34,12 @@ locals {
   group_files   = fileset(local.group_config_path, "*.yml")
   ruleset_files = fileset(local.ruleset_config_path, "*.yml")
 
+  # Membership directory is optional - missing directory results in empty set
+  membership_files = try(
+    fileset(local.membership_config_path, "*.yml"),
+    toset([])
+  )
+
   # Load individual YAML files (for duplicate detection)
   repository_configs_by_file = {
     for f in sort(tolist(local.repository_files)) :
@@ -45,6 +52,10 @@ locals {
   ruleset_configs_by_file = {
     for f in sort(tolist(local.ruleset_files)) :
     f => yamldecode(file("${local.ruleset_config_path}/${f}"))
+  }
+  membership_configs_by_file = {
+    for f in sort(tolist(local.membership_files)) :
+    f => try(yamldecode(file("${local.membership_config_path}/${f}")), {})
   }
 
   # Detect duplicate keys across files
@@ -101,6 +112,22 @@ locals {
 
   duplicate_ruleset_keys = {
     for key, files in local.ruleset_key_occurrences :
+    key => files if length(files) > 1
+  }
+
+  membership_key_occurrences = {
+    for key in distinct(flatten([
+      for file, config in local.membership_configs_by_file :
+      config != null ? keys(config) : []
+    ])) :
+    key => [
+      for file, config in local.membership_configs_by_file :
+      file if config != null && contains(keys(config), key)
+    ]
+  }
+
+  duplicate_membership_keys = {
+    for key, files in local.membership_key_occurrences :
     key => files if length(files) > 1
   }
 
@@ -252,6 +279,12 @@ locals {
     ])
   ]))
 
+  # Load and merge membership configs from config/membership/ directory (optional)
+  membership_config = merge([
+    for f in sort(tolist(local.membership_files)) :
+    try(yamldecode(file("${local.membership_config_path}/${f}")), {})
+  ]...)
+
   # Extract values from YAML
   github_org      = local.common_config.organization
   is_organization = lookup(local.common_config, "is_organization", true)
@@ -263,6 +296,12 @@ locals {
   # Defaults to null if not specified (no org-level actions resource created)
   # Only applicable for organizations, not personal accounts
   org_actions_config = local.is_organization ? lookup(local.common_config, "actions", null) : null
+
+  # Effective membership: only managed when explicitly enabled AND target is an organization
+  # Returns empty map when membership_management_enabled is false OR is_organization is false
+  effective_membership = (
+    var.membership_management_enabled && local.is_organization
+  ) ? local.membership_config : {}
 
   # Subscription tier feature availability
   # - free: Rulesets only work on public repositories


### PR DESCRIPTION
## Summary

Closes #35

Adds opt-in GitHub organization membership management via YAML configuration files in `config/membership/`. Members and their roles (`member`/`admin`) are defined as a flat `username: role` map, following the same split-file pattern already used for `repository/`, `group/`, `ruleset/`, and `webhook/` directories.

## Changes

| File | What changed |
|------|-------------|
| `yaml-config.tf` | `membership_config_path`, `membership_files` (optional via `try()`), `membership_configs_by_file`, `membership_config`, `membership_key_occurrences`, `duplicate_membership_keys`, `effective_membership` locals |
| `variables.tf` | `membership_management_enabled` (bool, default `false`) with safety and SCIM/SSO warnings |
| `main.tf` | `github_membership.this` resource iterating `effective_membership` |
| `outputs.tf` | `managed_members`, `managed_member_count` outputs; `duplicate_key_warnings` extended with membership duplicates |
| `config/membership/example-members.yml` | Commented example file with prominent destructive-operation and SCIM conflict warnings |
| `scripts/validate-config.py` | `validate_membership()` function; SCIM/SSO reminder printed when membership config is present |
| `AGENTS.md` | `config/membership/` in project structure; "Adding/managing organization members" section in Common Tasks |
| `examples/consumer/main.tf` | Commented `membership_management_enabled` with inline safety docs |

## Safety Design

- **Off by default** — `membership_management_enabled = false` means no membership resources are created even if `config/membership/` files exist
- **Org-only guard** — `effective_membership` returns `{}` when `is_organization = false`, so personal accounts are unaffected
- **No prevent_destroy** — intentional; the opt-in toggle is the safety mechanism. Destructive removals show clearly in `terraform plan` output
- **SCIM/SSO warning** — documented in variable description, example file, validate-config.py output, AGENTS.md, and consumer example

## Testing

- `terraform validate` passes ✓
- `scripts/validate-config.py` passes ✓
- `pre-commit run` passes on all modified files ✓ (pre-existing tflint warning in `examples/consumer/` is unrelated to this change)