### PR TITLE
feat(rulesets): add organization-level ruleset support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,16 @@ Edit `config/groups.yml`. Groups are merged when multiple are assigned to a repo
 
 Rulesets allow you to enforce branch protection and other repository rules across multiple repositories based on their groups.
 
-1. Edit `config/rulesets.yml` to define reusable rulesets
+There are two types of rulesets:
+
+- **Repository rulesets** (`scope: repository` or no `scope`) — applied per-repository, assigned
+  via `rulesets:` in groups or repositories.
+- **Organization rulesets** (`scope: organization`) — applied at the org level across multiple
+  repositories by `repository_name` pattern conditions. NOT assignable per-repo or per-group.
+
+#### Repository rulesets
+
+1. Edit a file in `config/ruleset/` to define a ruleset (no `scope` or `scope: repository`)
 1. Each ruleset must specify:
    - `target`: Type of target (e.g., `branch`, `tag`)
    - `enforcement`: Enforcement level (`active`, `evaluate`, or `disabled`)
@@ -68,7 +77,7 @@ Rulesets allow you to enforce branch protection and other repository rules acros
    - `rules`: Array of rules to enforce
 1. Reference rulesets in groups or repositories by adding a `rulesets:` field
 
-Example in `config/rulesets.yml`:
+Example in `config/ruleset/default-rulesets.yml`:
 
 ```yaml
 oss-main-protection:
@@ -110,6 +119,41 @@ my-special-repo:
     - custom-ruleset
 ```
 
+#### Organization rulesets
+
+Organization rulesets apply rules globally across repositories, filtered by `repository_name`
+conditions. They are defined in `config/ruleset/` with `scope: organization` and are NOT
+referenced via `rulesets:` in groups or repositories.
+
+Requires `team` or `enterprise` subscription. On `free`/`pro` plans, org rulesets are skipped
+with a warning in the `skipped_org_rulesets` output.
+
+Example in `config/ruleset/org-rulesets.yml`:
+
+```yaml
+org-main-protection:
+  scope: organization          # Required: marks this as an org-level ruleset
+  target: branch
+  enforcement: active
+  conditions:
+    ref_name:
+      include:
+        - "~DEFAULT_BRANCH"
+      exclude: []
+    repository_name:           # Optional: which repos this applies to (default: all)
+      include:
+        - "*"
+      exclude:
+        - "sandbox-*"
+  rules:
+    - type: deletion
+    - type: non_fast_forward
+    - type: pull_request
+      parameters:
+        required_approving_review_count: 1
+        dismiss_stale_reviews_on_push: true
+```
+
 Supported rule types:
 
 - `deletion` - Prevent branch deletion
@@ -120,7 +164,7 @@ Supported rule types:
 - `required_status_checks` - Require status checks to pass
 - `creation` - Control branch creation
 - `update` - Control branch updates
-- `required_deployments` - Require successful deployments
+- `required_deployments` - Require successful deployments (repository rulesets only)
 - `branch_name_pattern` - Enforce branch naming patterns
 - `commit_message_pattern` - Enforce commit message patterns
 - `commit_author_email_pattern` - Enforce commit author email patterns
@@ -132,9 +176,9 @@ Then run `terraform plan` to preview and `terraform apply` to apply.
 
 Rulesets availability depends on your GitHub subscription:
 
-- `free` - Rulesets only work on **public** repositories
-- `pro` - Rulesets work on public and private repos (personal accounts only)
-- `team` - Full ruleset support including push rulesets
+- `free` - Repository rulesets only work on **public** repositories; org rulesets skipped
+- `pro` - Repository rulesets work on public and private repos; org rulesets skipped
+- `team` - Full ruleset support including org rulesets
 - `enterprise` - Full feature set
 
 Set your subscription tier in `config/config.yml`:
@@ -185,6 +229,8 @@ Always review `terraform plan` output before applying.
 
 Only effective for organizations (`is_organization: true` in `config/config.yml`).
 Has no effect on personal accounts.
+If you configure org rulesets on a free or pro tier, they will be
+automatically skipped (listed in the `skipped_org_rulesets` output).
 
 ### Importing existing repositories
 

--- a/config/ruleset/default-rulesets.yml
+++ b/config/ruleset/default-rulesets.yml
@@ -5,6 +5,43 @@
 # 1. Applied directly by reference (e.g., rulesets: [oss-main-protection])
 # 2. Used as templates with the 'template' key (e.g., template: strict-main)
 #
+# ORGANIZATION-LEVEL RULESETS
+# Add 'scope: organization' to create a github_organization_ruleset instead of a
+# per-repository ruleset. Org rulesets apply across repositories based on
+# repository_name conditions. They require a 'team' or 'enterprise' subscription.
+#
+# Org rulesets CANNOT be referenced via 'rulesets:' in groups or repositories —
+# they are applied globally and filtered only by repository_name conditions.
+#
+# Example org ruleset (uncomment to enable):
+#
+# org-main-protection:
+#   scope: organization          # Required: marks this as an org-level ruleset
+#   target: branch
+#   enforcement: active
+#   conditions:
+#     ref_name:
+#       include:
+#         - "~DEFAULT_BRANCH"
+#       exclude: []
+#     repository_name:           # Optional: which repos this applies to (default: all)
+#       include:
+#         - "*"
+#       exclude:
+#         - "sandbox-*"
+#         - "test-*"
+#   bypass_actors:
+#     - actor_type: RepositoryRole
+#       actor_id: 5              # Admin role
+#       bypass_mode: always
+#   rules:
+#     - type: deletion
+#     - type: non_fast_forward
+#     - type: pull_request
+#       parameters:
+#         required_approving_review_count: 1
+#         dismiss_stale_reviews_on_push: true
+#
 # When using templates in repositories.yml or groups.yml:
 #   rulesets:
 #     - template: strict-main

--- a/main.tf
+++ b/main.tf
@@ -80,6 +80,135 @@ resource "github_membership" "this" {
   }
 }
 
+# Organization-level rulesets
+# Applied globally across repositories based on repository_name conditions
+# Requires team or enterprise subscription (skipped on free/pro - see skipped_org_rulesets output)
+resource "github_organization_ruleset" "this" {
+  for_each = local.effective_org_rulesets
+
+  name        = each.key
+  target      = each.value.target
+  enforcement = each.value.enforcement
+
+  conditions {
+    ref_name {
+      include = each.value.conditions.ref_name.include
+      exclude = each.value.conditions.ref_name.exclude
+    }
+
+    # repository_name is optional; defaults to all repositories when omitted
+    dynamic "repository_name" {
+      for_each = lookup(lookup(each.value, "conditions", {}), "repository_name", null) != null ? [each.value.conditions.repository_name] : []
+      content {
+        include = lookup(repository_name.value, "include", ["*"])
+        exclude = lookup(repository_name.value, "exclude", [])
+      }
+    }
+  }
+
+  # Bypass actors - allow specific users/teams/apps to bypass rules
+  dynamic "bypass_actors" {
+    for_each = lookup(each.value, "bypass_actors", null) != null ? each.value.bypass_actors : []
+    content {
+      actor_id    = bypass_actors.value.actor_id
+      actor_type  = bypass_actors.value.actor_type
+      bypass_mode = lookup(bypass_actors.value, "bypass_mode", "always")
+    }
+  }
+
+  # Rules - single block containing all rule types
+  rules {
+    # Branch name pattern rule
+    dynamic "branch_name_pattern" {
+      for_each = [for rule in each.value.rules : rule if rule.type == "branch_name_pattern"]
+      content {
+        operator = lookup(branch_name_pattern.value.parameters, "operator", "starts_with")
+        pattern  = branch_name_pattern.value.parameters.pattern
+        name     = lookup(branch_name_pattern.value.parameters, "name", null)
+        negate   = lookup(branch_name_pattern.value.parameters, "negate", false)
+      }
+    }
+
+    # Deletion rule
+    deletion = contains([for rule in each.value.rules : rule.type], "deletion") ? true : null
+
+    # Non-fast-forward rule
+    non_fast_forward = contains([for rule in each.value.rules : rule.type], "non_fast_forward") ? true : null
+
+    # Required linear history rule
+    required_linear_history = contains([for rule in each.value.rules : rule.type], "required_linear_history") ? true : null
+
+    # Required signatures rule
+    required_signatures = contains([for rule in each.value.rules : rule.type], "required_signatures") ? true : null
+
+    # Pull request rule
+    dynamic "pull_request" {
+      for_each = [for rule in each.value.rules : rule if rule.type == "pull_request"]
+      content {
+        required_approving_review_count   = lookup(pull_request.value.parameters, "required_approving_review_count", 1)
+        dismiss_stale_reviews_on_push     = lookup(pull_request.value.parameters, "dismiss_stale_reviews_on_push", false)
+        require_code_owner_review         = lookup(pull_request.value.parameters, "require_code_owner_review", false)
+        require_last_push_approval        = lookup(pull_request.value.parameters, "require_last_push_approval", false)
+        required_review_thread_resolution = lookup(pull_request.value.parameters, "required_review_thread_resolution", false)
+      }
+    }
+
+    # Required status checks rule
+    dynamic "required_status_checks" {
+      for_each = [for rule in each.value.rules : rule if rule.type == "required_status_checks"]
+      content {
+        dynamic "required_check" {
+          for_each = lookup(required_status_checks.value.parameters, "required_checks", [])
+          content {
+            context        = required_check.value.context
+            integration_id = lookup(required_check.value, "integration_id", null)
+          }
+        }
+        strict_required_status_checks_policy = lookup(required_status_checks.value.parameters, "strict_required_status_checks_policy", false)
+      }
+    }
+
+    # Creation rule
+    creation = contains([for rule in each.value.rules : rule.type], "creation") ? true : null
+
+    # Update rule
+    update = contains([for rule in each.value.rules : rule.type], "update") ? true : null
+
+    # Commit message pattern rule
+    dynamic "commit_message_pattern" {
+      for_each = [for rule in each.value.rules : rule if rule.type == "commit_message_pattern"]
+      content {
+        operator = lookup(commit_message_pattern.value.parameters, "operator", "starts_with")
+        pattern  = commit_message_pattern.value.parameters.pattern
+        name     = lookup(commit_message_pattern.value.parameters, "name", null)
+        negate   = lookup(commit_message_pattern.value.parameters, "negate", false)
+      }
+    }
+
+    # Commit author email pattern rule
+    dynamic "commit_author_email_pattern" {
+      for_each = [for rule in each.value.rules : rule if rule.type == "commit_author_email_pattern"]
+      content {
+        operator = lookup(commit_author_email_pattern.value.parameters, "operator", "starts_with")
+        pattern  = commit_author_email_pattern.value.parameters.pattern
+        name     = lookup(commit_author_email_pattern.value.parameters, "name", null)
+        negate   = lookup(commit_author_email_pattern.value.parameters, "negate", false)
+      }
+    }
+
+    # Committer email pattern rule
+    dynamic "committer_email_pattern" {
+      for_each = [for rule in each.value.rules : rule if rule.type == "committer_email_pattern"]
+      content {
+        operator = lookup(committer_email_pattern.value.parameters, "operator", "starts_with")
+        pattern  = committer_email_pattern.value.parameters.pattern
+        name     = lookup(committer_email_pattern.value.parameters, "name", null)
+        negate   = lookup(committer_email_pattern.value.parameters, "negate", false)
+      }
+    }
+  }
+}
+
 # Organization-level Actions permissions
 # Only created when actions configuration is specified in config.yml
 resource "github_actions_organization_permissions" "this" {

--- a/main.tf
+++ b/main.tf
@@ -96,13 +96,11 @@ resource "github_organization_ruleset" "this" {
       exclude = each.value.conditions.ref_name.exclude
     }
 
-    # repository_name is optional; defaults to all repositories when omitted
-    dynamic "repository_name" {
-      for_each = lookup(lookup(each.value, "conditions", {}), "repository_name", null) != null ? [each.value.conditions.repository_name] : []
-      content {
-        include = lookup(repository_name.value, "include", ["*"])
-        exclude = lookup(repository_name.value, "exclude", [])
-      }
+    # repository_name is required by the GitHub provider (AtLeastOneOf constraint).
+    # When omitted from YAML config, defaults to include all repositories.
+    repository_name {
+      include = lookup(lookup(lookup(each.value, "conditions", {}), "repository_name", {}), "include", ["*"])
+      exclude = lookup(lookup(lookup(each.value, "conditions", {}), "repository_name", {}), "exclude", [])
     }
   }
 

--- a/openspec/changes/add-org-rulesets/specs/repository-management/spec.md
+++ b/openspec/changes/add-org-rulesets/specs/repository-management/spec.md
@@ -1,0 +1,73 @@
+# Spec Delta: Repository Management — Organization Rulesets
+
+## MODIFIED Requirements
+
+### Requirement: Repository Rulesets (MODIFIED)
+
+**Original:** The system SHALL support repository rulesets for branch protection and policy enforcement.
+
+**Modification:** Repository rulesets are limited to definitions with `scope: repository` or no
+`scope` field. Definitions with `scope: organization` are excluded from the per-repository
+rulesets map and are not available for assignment via `rulesets:` in groups or repositories.
+Attempting to reference an org-scoped ruleset per-repository is a misconfiguration.
+
+#### Scenario: Org-scoped ruleset excluded from per-repository rulesets
+
+- **GIVEN** `config/ruleset/` contains a ruleset with `scope: organization`
+- **AND** another ruleset with no `scope` field (repo-scoped)
+- **WHEN** Terraform parses the configuration
+- **THEN** only the repo-scoped ruleset is available for assignment via `rulesets:` in groups/repos
+- **AND** the org-scoped ruleset is not included in the per-repository rulesets map
+
+______________________________________________________________________
+
+## MODIFIED Requirements (Subscription Tier Awareness)
+
+### Requirement: Subscription Tier Awareness (MODIFIED)
+
+**Addition:** The system SHALL skip organization-level rulesets (`scope: organization`) on `free`
+and `pro` plans, and SHALL emit a `skipped_org_rulesets` output listing the names of skipped
+org rulesets. Organization rulesets require a `team` or `enterprise` subscription.
+
+The existing behaviour for repository-level rulesets on private repos is unchanged: on `free`
+plans, rulesets are skipped for private repos and listed in `subscription_warnings`.
+
+#### Scenario: Free tier — org rulesets skipped with output
+
+- **GIVEN** `subscription: free` is configured in `config.yml`
+- **AND** at least one org ruleset (`scope: organization`) is defined
+- **WHEN** `terraform plan` is executed
+- **THEN** no `github_organization_ruleset` resources are planned
+- **AND** the `skipped_org_rulesets` output contains the names of the skipped org rulesets
+
+#### Scenario: Pro tier — org rulesets skipped
+
+- **GIVEN** `subscription: pro` is configured
+- **AND** at least one org ruleset is defined
+- **WHEN** `terraform plan` is executed
+- **THEN** no `github_organization_ruleset` resources are planned
+
+#### Scenario: Team tier — org rulesets applied
+
+- **GIVEN** `subscription: team` is configured
+- **AND** at least one org ruleset is defined
+- **WHEN** `terraform apply` is executed
+- **THEN** `github_organization_ruleset` resources are created for all org rulesets
+- **AND** `skipped_org_rulesets` output is null
+
+#### Scenario: Enterprise tier — org rulesets applied
+
+- **GIVEN** `subscription: enterprise` is configured
+- **WHEN** `terraform apply` is executed
+- **THEN** all org rulesets are created without restriction
+
+______________________________________________________________________
+
+## ADDED Requirements
+
+### Requirement: Organization Rulesets
+
+The system SHALL support organization-level rulesets that apply rules across multiple repositories
+based on repository name patterns, using `github_organization_ruleset`.
+
+See `openspec/changes/add-org-rulesets/specs/org-ruleset-management/spec.md` for full scenarios.

--- a/openspec/changes/add-org-rulesets/tasks.md
+++ b/openspec/changes/add-org-rulesets/tasks.md
@@ -2,104 +2,24 @@
 
 ## Ordered Work Items
 
-### 1. Parse and separate org rulesets in `yaml-config.tf`
-
-Add a local that filters `rulesets_config` into two maps:
-
-- `repo_rulesets_config` — entries without `scope` or with `scope: repository`
-- `org_rulesets_config` — entries with `scope: organization`
-
-This keeps the existing `merged_rulesets`/`effective_rulesets` logic working unchanged (it already
-uses `rulesets_config` which will continue to contain only repo-scoped entries).
-
-**Validates:** `terraform validate`; confirm org rulesets are separated from repo rulesets.
-
-______________________________________________________________________
-
-### 2. Apply subscription tier filtering for org rulesets
-
-Add a local `org_rulesets_require_paid` that skips org rulesets when `subscription` is `free` or
-`pro`, mirroring the existing `rulesets_require_paid_for_private` logic.
-
-Add a local `effective_org_rulesets` that returns `{}` when the subscription is insufficient,
-with a warning output similar to `repos_with_skipped_rulesets`.
-
-**Validates:** Set `subscription: free` in `config.yml` and confirm org rulesets are not created.
-
-______________________________________________________________________
-
-### 3. Add `github_organization_ruleset` resource in `main.tf`
-
-Create a new `resource "github_organization_ruleset" "this"` using `for_each` over
-`local.effective_org_rulesets`. This resource mirrors the structure of
-`github_repository_ruleset` in `modules/repository/main.tf` but uses
-`repository_name` conditions from the org ruleset config.
-
-The `conditions` block must support both `ref_name` and `repository_name` sub-blocks.
-`repository_name` is optional (default: include `["*"]`, exclude `[]`).
-
-**Validates:** `terraform plan` with an org ruleset defined; confirm resource appears in plan.
-
-______________________________________________________________________
-
-### 4. Update `config/ruleset/default-rulesets.yml` with an example org ruleset
-
-Add a commented-out example org ruleset to the default ruleset config file to demonstrate
-the `scope: organization` field and `repository_name` conditions.
-
-**Validates:** Manual review; validate-config.py should not error.
-
-______________________________________________________________________
-
-### 5. Update `scripts/validate-config.py` to accept `scope` field
-
-The validation script should recognise `scope: organization` and `scope: repository` as valid
-fields on a ruleset definition. Org rulesets should also be checked to ensure they are not
-referenced via `rulesets:` on repositories or groups (since org rulesets apply globally and
-referencing them per-repo is a misconfiguration).
-
-**Validates:** Run `scripts/validate-config.py` with org ruleset config; confirm no false errors.
-
-______________________________________________________________________
-
-### 6. Add spec delta for org ruleset management
-
-Write the spec delta in `openspec/changes/add-org-rulesets/specs/org-ruleset-management/spec.md`
-covering:
-
-- `scope: organization` field on ruleset definitions
-- `repository_name` conditions
-- Subscription tier gating (team/enterprise only)
-- org rulesets NOT being assignable to repos/groups via `rulesets:` key
-
-**Validates:** `openspec validate add-org-rulesets --strict`
-
-______________________________________________________________________
-
-### 7. Update `repository-management` spec
-
-Add a `MODIFIED` requirement to the existing `Repository Rulesets` requirement and a new
-`Organization Rulesets` requirement. Update `Subscription Tier Awareness` to cover org rulesets.
-
-**Validates:** `openspec validate add-org-rulesets --strict`
-
-______________________________________________________________________
-
-### 8. Update `AGENTS.md` and template YAML examples
-
-Document the `scope` field in `AGENTS.md` ruleset docs and update the `config/ruleset/` example.
-
-**Validates:** Manual review.
-
-______________________________________________________________________
+- [x] Task 1: Parse and separate org rulesets in `yaml-config.tf`
+  — add `repo_rulesets_config` and `org_rulesets_config` locals split by `scope`
+- [x] Task 2: Apply subscription tier filtering for org rulesets
+  — add `org_rulesets_require_paid`, `effective_org_rulesets`; add `skipped_org_rulesets` output
+- [x] Task 3: Add `github_organization_ruleset` resource in `main.tf`
+  — `for_each` over `local.effective_org_rulesets` with `ref_name` + optional `repository_name`
+- [x] Task 4: Update `config/ruleset/default-rulesets.yml` with a commented-out example
+  org ruleset demonstrating `scope: organization` and `repository_name` conditions
+- [x] Task 5: Update `scripts/validate-config.py` to accept `scope` field on rulesets
+  and warn when org rulesets are referenced per-repository or per-group
+- [x] Task 6: Add spec delta for org ruleset management
+  (already written at `specs/org-ruleset-management/spec.md`)
+- [x] Task 7: Update `repository-management` spec — add `MODIFIED` requirement for
+  Repository Rulesets and new `Organization Rulesets` requirement
+- [x] Task 8: Update `AGENTS.md` and template YAML examples to document the `scope` field
 
 ## Dependencies
 
 - Tasks 1 → 2 → 3 (sequential: parsing feeds filtering feeds resource creation)
 - Tasks 4, 5, 8 can run in parallel with each other after Task 1
 - Tasks 6, 7 can run after all implementation tasks are drafted
-
-## Parallelizable Work
-
-- Tasks 4, 5, 8 are independent of each other
-- Tasks 6, 7 are independent of each other and can be done once implementation shape is stable

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,6 +53,16 @@ output "managed_member_count" {
   value       = length(github_membership.this)
 }
 
+# Output warning when org rulesets are skipped due to subscription tier
+output "skipped_org_rulesets" {
+  description = "Org rulesets skipped because the subscription tier (free/pro) does not support them"
+  value = length(local.skipped_org_ruleset_names) > 0 ? {
+    message  = "Organization rulesets skipped - requires team or enterprise GitHub plan"
+    rulesets = local.skipped_org_ruleset_names
+    tier     = local.subscription
+  } : null
+}
+
 # Output warning when duplicate keys are detected across config files
 # Duplicates cause shallow merge - the entire definition from the later file wins
 output "duplicate_key_warnings" {

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -39,6 +39,7 @@ VALID_RULE_TYPES = [
     "commit_author_email_pattern",
     "committer_email_pattern",
 ]
+VALID_SCOPES = ["organization", "repository"]
 
 VALID_TEAM_PRIVACIES = ["closed", "secret"]
 VALID_DELEGATION_ALGORITHMS = ["round_robin", "load_balance"]
@@ -66,6 +67,23 @@ def load_yaml_directory(directory: Path) -> dict:
     return merged
 
 
+def split_rulesets_by_scope(rulesets: dict) -> tuple[dict, dict]:
+    """Split rulesets into repo-scoped and org-scoped maps.
+
+    Returns (repo_rulesets, org_rulesets).
+    Definitions without 'scope' or with 'scope: repository' are repo-scoped.
+    Definitions with 'scope: organization' are org-scoped.
+    """
+    repo_rulesets = {}
+    org_rulesets = {}
+    for name, config in rulesets.items():
+        if isinstance(config, dict) and config.get("scope") == "organization":
+            org_rulesets[name] = config
+        else:
+            repo_rulesets[name] = config
+    return repo_rulesets, org_rulesets
+
+
 def validate_config(config: dict) -> list[str]:
     """Validate config.yml."""
     errors = []
@@ -80,7 +98,7 @@ def validate_config(config: dict) -> list[str]:
     return errors
 
 
-def validate_groups(groups: dict) -> list[str]:
+def validate_groups(groups: dict, org_ruleset_names: set) -> list[str]:
     """Validate groups configuration."""
     errors = []
 
@@ -105,10 +123,25 @@ def validate_groups(groups: dict) -> list[str]:
                         f"groups: Group '{group_name}' team '{team}' has invalid permission '{permission}'"
                     )
 
+        # Org rulesets must not be assigned to groups via rulesets:
+        for ruleset_entry in group_config.get("rulesets", []):
+            entry_name = (
+                ruleset_entry
+                if isinstance(ruleset_entry, str)
+                else ruleset_entry.get("template", "")
+            )
+            if entry_name in org_ruleset_names:
+                errors.append(
+                    f"groups: Group '{group_name}' references org-scoped ruleset '{entry_name}' "
+                    f"via 'rulesets:' — org rulesets apply globally and cannot be assigned per-group"
+                )
+
     return errors
 
 
-def validate_repositories(repos: dict, groups: dict, rulesets: dict) -> list[str]:
+def validate_repositories(
+    repos: dict, groups: dict, repo_rulesets: dict, org_ruleset_names: set
+) -> list[str]:
     """Validate repositories configuration."""
     errors = []
 
@@ -154,13 +187,23 @@ def validate_repositories(repos: dict, groups: dict, rulesets: dict) -> list[str
         for ruleset_entry in repo_config.get("rulesets", []):
             # Handle both string references and template references
             if isinstance(ruleset_entry, str):
-                if ruleset_entry not in rulesets:
+                if ruleset_entry in org_ruleset_names:
+                    errors.append(
+                        f"repositories: Repository '{repo_name}' references org-scoped ruleset '{ruleset_entry}' "
+                        f"via 'rulesets:' — org rulesets apply globally and cannot be assigned per-repository"
+                    )
+                elif ruleset_entry not in repo_rulesets:
                     errors.append(
                         f"repositories: Repository '{repo_name}' references unknown ruleset '{ruleset_entry}'"
                     )
             elif isinstance(ruleset_entry, dict) and "template" in ruleset_entry:
                 template_name = ruleset_entry["template"]
-                if template_name not in rulesets:
+                if template_name in org_ruleset_names:
+                    errors.append(
+                        f"repositories: Repository '{repo_name}' references org-scoped ruleset '{template_name}' "
+                        f"via 'rulesets:' — org rulesets apply globally and cannot be assigned per-repository"
+                    )
+                elif template_name not in repo_rulesets:
                     errors.append(
                         f"repositories: Repository '{repo_name}' references unknown template '{template_name}'"
                     )
@@ -176,6 +219,14 @@ def validate_rulesets(rulesets: dict) -> list[str]:
         if not isinstance(ruleset_config, dict):
             errors.append(f"rulesets: Ruleset '{ruleset_name}' must be a dictionary")
             continue
+
+        # Validate scope if specified
+        scope = ruleset_config.get("scope")
+        if scope is not None and scope not in VALID_SCOPES:
+            errors.append(
+                f"rulesets: Ruleset '{ruleset_name}' has invalid scope '{scope}' "
+                f"(valid: {', '.join(VALID_SCOPES)})"
+            )
 
         # Check required fields
         if "target" not in ruleset_config:
@@ -457,6 +508,8 @@ def check_team_cross_references(
             )
 
     return warnings
+
+
 def validate_membership(members: dict) -> list[str]:
     """Validate membership configuration."""
     errors = []
@@ -554,11 +607,14 @@ def main():
         print(f"ERROR: {e}")
         sys.exit(1)
 
+    # Separate rulesets by scope for targeted validation
+    repo_rulesets, org_rulesets = split_rulesets_by_scope(rulesets)
+    org_ruleset_names = set(org_rulesets.keys())
+
     # Validate each config type
     all_errors.extend(validate_config(config))
-    all_errors.extend(validate_groups(groups))
+    all_errors.extend(validate_groups(groups, org_ruleset_names))
     all_errors.extend(validate_rulesets(rulesets))
-    all_errors.extend(validate_repositories(repos, groups, rulesets))
     all_errors.extend(validate_membership(members))
 
     # Print SCIM/SSO reminder when membership config is present
@@ -582,6 +638,18 @@ def main():
     if flat_teams:
         managed_slugs = {t["slug"] for t in flat_teams}
         team_xref_warnings = check_team_cross_references(repos, groups, managed_slugs)
+    all_errors.extend(
+        validate_repositories(repos, groups, repo_rulesets, org_ruleset_names)
+    )
+
+    # Warn about subscription tier and org rulesets
+    subscription = config.get("subscription", "free")
+    if org_rulesets and subscription in ("free", "pro"):
+        print(
+            f"WARNING: {len(org_rulesets)} org ruleset(s) defined but subscription is '{subscription}' "
+            f"— org rulesets require 'team' or 'enterprise' and will be skipped by Terraform."
+        )
+        print()
 
     # Report results
     if all_errors:
@@ -614,6 +682,9 @@ def main():
 
         if members:
             print(f"  - Members: {len(members)}")
+        print(f"  - Rulesets (repo-scoped): {len(repo_rulesets)}")
+        if org_rulesets:
+            print(f"  - Rulesets (org-scoped): {len(org_rulesets)}")
         sys.exit(0)
 
 

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -7,6 +7,8 @@ Usage:
     python scripts/validate-config.py --strict
 """
 
+from __future__ import annotations
+
 import re
 import sys
 import yaml
@@ -125,11 +127,16 @@ def validate_groups(groups: dict, org_ruleset_names: set) -> list[str]:
 
         # Org rulesets must not be assigned to groups via rulesets:
         for ruleset_entry in group_config.get("rulesets", []):
-            entry_name = (
-                ruleset_entry
-                if isinstance(ruleset_entry, str)
-                else ruleset_entry.get("template", "")
-            )
+            if isinstance(ruleset_entry, str):
+                entry_name = ruleset_entry
+            elif isinstance(ruleset_entry, dict):
+                entry_name = ruleset_entry.get("template", "")
+            else:
+                errors.append(
+                    f"groups: Group '{group_name}' has invalid ruleset entry "
+                    f"'{ruleset_entry}' (must be a string or dictionary)"
+                )
+                continue
             if entry_name in org_ruleset_names:
                 errors.append(
                     f"groups: Group '{group_name}' references org-scoped ruleset '{entry_name}' "
@@ -249,6 +256,7 @@ def validate_rulesets(rulesets: dict) -> list[str]:
         if "rules" not in ruleset_config:
             errors.append(f"rulesets: Ruleset '{ruleset_name}' missing 'rules'")
         else:
+            is_org_scoped = ruleset_config.get("scope") == "organization"
             for rule in ruleset_config["rules"]:
                 if "type" not in rule:
                     errors.append(
@@ -257,6 +265,11 @@ def validate_rulesets(rulesets: dict) -> list[str]:
                 elif rule["type"] not in VALID_RULE_TYPES:
                     errors.append(
                         f"rulesets: Ruleset '{ruleset_name}' has invalid rule type '{rule['type']}'"
+                    )
+                elif is_org_scoped and rule["type"] == "required_deployments":
+                    errors.append(
+                        f"rulesets: Org-scoped ruleset '{ruleset_name}' uses rule type "
+                        f"'required_deployments' which is not supported for organization rulesets"
                     )
 
     return errors

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -151,6 +151,23 @@ locals {
     if f != "templates.yml" # Exclude templates from regular rulesets
   ]...)
 
+  # Separate rulesets by scope
+  # - repo_rulesets_config: definitions without 'scope' or with 'scope: repository'
+  #   These are available for assignment via rulesets: in groups and repositories
+  # - org_rulesets_config: definitions with 'scope: organization'
+  #   These are applied as github_organization_ruleset resources, not per-repository
+  repo_rulesets_config = {
+    for name, config in local.rulesets_config :
+    name => config
+    if lookup(config, "scope", "repository") != "organization"
+  }
+
+  org_rulesets_config = {
+    for name, config in local.rulesets_config :
+    name => config
+    if lookup(config, "scope", "repository") == "organization"
+  }
+
   # Load ruleset templates from config/ruleset/default-rulesets.yml
   # Templates are referenced by name in repository/group configurations
   # This file now contains both templates and default rulesets
@@ -312,6 +329,17 @@ locals {
   # - team/enterprise: Full ruleset support including push rulesets
   rulesets_require_paid_for_private = contains(["free"], local.subscription)
 
+  # Organization rulesets require team or enterprise subscription
+  # On free or pro plans, all org rulesets are skipped with a warning
+  org_rulesets_require_paid = contains(["free", "pro"], local.subscription)
+
+  # Effective org rulesets after subscription tier filtering
+  # Returns empty map when subscription is insufficient
+  effective_org_rulesets = local.org_rulesets_require_paid ? tomap({}) : local.org_rulesets_config
+
+  # Track which org rulesets are skipped due to subscription tier
+  skipped_org_ruleset_names = local.org_rulesets_require_paid ? keys(local.org_rulesets_config) : []
+
   # Merge multiple config groups for each repository
   # Groups are applied sequentially: later groups override single values, lists are merged
   merged_configs = {
@@ -393,7 +421,8 @@ locals {
             ) : null # Template doesn't exist - will be filtered out
             ) : (
             # Direct ruleset name reference (existing behavior)
-            lookup(local.rulesets_config, ruleset_entry, null)
+            # Only looks up repo-scoped rulesets; org-scoped rulesets are excluded here
+            lookup(local.repo_rulesets_config, ruleset_entry, null)
           )
         )
       }

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -329,16 +329,17 @@ locals {
   # - team/enterprise: Full ruleset support including push rulesets
   rulesets_require_paid_for_private = contains(["free"], local.subscription)
 
-  # Organization rulesets require team or enterprise subscription
-  # On free or pro plans, all org rulesets are skipped with a warning
-  org_rulesets_require_paid = contains(["free", "pro"], local.subscription)
+  # Organization rulesets require organization mode and team/enterprise subscription
+  # On free or pro plans, or when not in organization mode, all org rulesets are skipped
+  org_rulesets_require_paid = local.is_organization && contains(["free", "pro"], local.subscription)
 
-  # Effective org rulesets after subscription tier filtering
-  # Returns empty map when subscription is insufficient
-  effective_org_rulesets = local.org_rulesets_require_paid ? tomap({}) : local.org_rulesets_config
+  # Effective org rulesets after account type and subscription tier filtering
+  # Returns empty map when not in organization mode or when subscription is insufficient
+  effective_org_rulesets = local.is_organization && !local.org_rulesets_require_paid ? local.org_rulesets_config : tomap({})
 
   # Track which org rulesets are skipped due to subscription tier
-  skipped_org_ruleset_names = local.org_rulesets_require_paid ? keys(local.org_rulesets_config) : []
+  # (only meaningful in organization mode; personal accounts simply never have org rulesets)
+  skipped_org_ruleset_names = local.is_organization && local.org_rulesets_require_paid ? keys(local.org_rulesets_config) : []
 
   # Merge multiple config groups for each repository
   # Groups are applied sequentially: later groups override single values, lists are merged


### PR DESCRIPTION
## Summary

Closes #29.

Ruleset definitions with \`scope: organization\` are applied globally across repositories
(filtered by optional \`repository_name\` conditions), while existing per-repository ruleset
behaviour is unchanged.

## Changes

### Core (\`yaml-config.tf\`)

- Split \`rulesets_config\` into \`repo_rulesets_config\` and \`org_rulesets_config\` based on
  the \`scope\` field
- Existing \`merged_rulesets\` / \`effective_rulesets\` logic now uses \`repo_rulesets_config\`
  — no behaviour change for repo-scoped rulesets

### Subscription tier gating (\`yaml-config.tf\`, \`outputs.tf\`)

- Org rulesets require \`team\` or \`enterprise\`; skipped on \`free\` / \`pro\`
- New \`skipped_org_rulesets\` output lists skipped ruleset names + current tier

### New resource (\`main.tf\`)

- \`github_organization_ruleset\` with \`for_each\` over \`local.effective_org_rulesets\`
- Supports \`ref_name\` conditions (required) + \`repository_name\` conditions (optional,
  defaults to all repos)
- Supports all rule types except \`required_deployments\` (not supported by the GitHub API
  for org rulesets)
- Supports \`bypass_actors\`

### Validation (\`scripts/validate-config.py\`)

- Accepts \`scope: organization\` / \`scope: repository\` as valid ruleset fields
- Errors when org-scoped rulesets are referenced via \`rulesets:\` on a group or repository
- Warns at validation time when org rulesets exist but the subscription tier will skip them

### Config example (\`config/ruleset/default-rulesets.yml\`)

- Commented-out org ruleset example demonstrating \`scope\`, \`repository_name\` conditions,
  and \`bypass_actors\`

### Docs (\`AGENTS.md\`)

- New "Organization rulesets" section with YAML example and subscription tier table

### Specs (\`openspec/changes/add-org-rulesets/\`)

- \`specs/repository-management/spec.md\`: delta for Repository Rulesets (MODIFIED) and
  Subscription Tier Awareness (MODIFIED)
- \`tasks.md\`: converted to checkbox format, all 8 tasks marked complete

## Backward compatibility

- Ruleset definitions without \`scope\` continue to work as repository-level rulesets
  — no migration needed
- \`subscription_warnings\` output for private-repo repo rulesets is unchanged

## Testing

\`\`\`bash
terraform validate                    # ✓ passes
python3 scripts/validate-config.py   # ✓ Validation PASSED (10 repo-scoped rulesets)
pre-commit run --files <changed>      # ✓ all hooks pass
\`\`\`