### PR TITLE
feat(webhooks): add organization webhook support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,43 @@ Only effective for organizations (`is_organization: true` in `config/config.yml`
 Has no effect on personal accounts.
 If you configure org rulesets on a free or pro tier, they will be
 automatically skipped (listed in the `skipped_org_rulesets` output).
+### Configuring organization webhooks
+
+Organization webhooks fire for events across **all** repositories in the organization — unlike
+repository webhooks which are scoped to a single repo. They are ideal for centralized audit
+logging, org-wide CI/CD notifications, and security monitoring.
+
+1. Define the webhook in `config/webhook/` (reuses the same format as repo webhooks):
+
+```yaml
+# config/webhook/my-webhooks.yml
+audit-logger:
+  url: https://audit.example.com/github
+  content_type: json
+  secret: env:ORG_WEBHOOK_SECRET
+  events:
+    - repository   # Repo created, deleted, renamed, or visibility changed
+    - member       # Member added or removed
+    - team         # Team created, deleted, or modified
+    - organization # Org member added, removed, or invited
+  active: true
+```
+
+1. Reference the webhook by name in `config/config.yml`:
+
+```yaml
+org_webhooks:
+  - audit-logger
+```
+
+1. Run `terraform plan` to preview, then `terraform apply`
+
+**Important notes:**
+
+- Org webhooks are **organization-only** — they are silently skipped when `is_organization: false`
+- Webhooks must be defined in `config/webhook/` before they can be referenced in `org_webhooks`
+- Secrets follow the same `env:VAR_NAME` pattern as repo webhooks; pass via `webhook_secrets` variable
+- Org webhooks work on all GitHub subscription tiers (no tier gating)
 
 ### Importing existing repositories
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -71,6 +71,14 @@ defaults:
 #   secret_scanning_enabled_for_new_repositories: false
 #   secret_scanning_push_protection_enabled_for_new_repositories: false
 #   members_can_create_internal_repositories: false
+# Organization-level webhooks (optional)
+# Org webhooks fire for events across ALL repositories in the organization.
+# Webhooks must be defined in config/webhook/ and referenced here by name.
+# Only applicable for organizations (not personal accounts).
+#
+# org_webhooks:
+#   - audit-logger    # Must be defined in config/webhook/
+#   - ci-notifier
 
 # Organization-level GitHub Actions configuration (optional)
 # Uncomment and configure to manage Actions permissions at the organization level

--- a/config/webhook/examples.yml
+++ b/config/webhook/examples.yml
@@ -53,3 +53,28 @@
 #     - push
 #     - pull_request
 #   active: true
+
+# Organization-level webhook examples (reference in config.yml under org_webhooks:)
+# These fire for ALL repositories in the organization, not just individual repos.
+
+# audit-logger:
+#   url: https://audit.example.com/github
+#   content_type: json
+#   secret: env:ORG_WEBHOOK_SECRET # pragma: allowlist secret
+#   events:
+#     - repository       # Repo created, deleted, renamed, visibility changed
+#     - member           # Member added or removed
+#     - team             # Team created, deleted, or modified
+#     - organization     # Org member added, removed, or invited
+#     - membership       # User added or removed from a team
+#   active: true
+
+# ci-notifier:
+#   url: https://ci.example.com/github-events
+#   content_type: json
+#   events:
+#     - push
+#     - pull_request
+#     - check_suite
+#     - workflow_run
+#   active: true

--- a/examples/consumer/main.tf
+++ b/examples/consumer/main.tf
@@ -65,8 +65,11 @@ module "github_org" {
   # repository_partitions = []  # default: all partitions
 
   # Optional: pass webhook secrets via environment variables or a secrets manager.
+  # Used for both repository-level and organization-level webhooks that use
+  # the env:VAR_NAME secret pattern in config/webhook/.
   # webhook_secrets = {
-  #   MY_WEBHOOK_SECRET = var.my_webhook_secret
+  #   MY_WEBHOOK_SECRET       = var.my_webhook_secret
+  #   ORG_WEBHOOK_SECRET      = var.org_webhook_secret
   # }
 
   # Optional: enable organization membership management via config/membership/.
@@ -78,4 +81,8 @@ module "github_org" {
   # WARNING: Do NOT enable alongside SCIM/IdP provisioning (Okta, Azure AD, SCIM) — they conflict.
   #
   # membership_management_enabled = true
+  #
+  # Organization webhooks are configured in config/config.yml under org_webhooks:.
+  # They fire for events across ALL repositories in the organization.
+  # Example: org_webhooks: [audit-logger, ci-notifier]
 }

--- a/main.tf
+++ b/main.tf
@@ -210,6 +210,23 @@ resource "github_organization_ruleset" "this" {
   }
 }
 
+# Organization-level webhooks
+# Fires for events across ALL repositories in the organization.
+# Only created when org_webhooks is configured in config.yml and is_organization is true.
+resource "github_organization_webhook" "this" {
+  for_each = local.resolved_org_webhooks
+
+  events = each.value.events
+  active = each.value.active
+
+  configuration {
+    url          = each.value.url
+    content_type = each.value.content_type
+    secret       = each.value.secret
+    insecure_ssl = each.value.insecure_ssl
+  }
+}
+
 # Organization-level Actions permissions
 # Only created when actions configuration is specified in config.yml
 resource "github_actions_organization_permissions" "this" {

--- a/openspec/changes/add-org-webhooks/specs/repository-management/spec.md
+++ b/openspec/changes/add-org-webhooks/specs/repository-management/spec.md
@@ -47,7 +47,7 @@ webhooks fire for events across all repositories in the organization.
 #### Scenario: Org webhook with secret resolution
 
 - **GIVEN** a webhook defines `secret: env:ORG_WEBHOOK_SECRET`
-- **AND** `var.webhook_secrets` contains `{ ORG_WEBHOOK_SECRET = "supersecret" }`
+- **AND** `var.webhook_secrets` contains `{ ORG_WEBHOOK_SECRET = "supersecret" }` <!-- pragma: allowlist secret -->
 - **WHEN** `terraform apply` is executed
 - **THEN** the org webhook is created with the resolved secret value
 - **AND** the secret is marked as sensitive in Terraform state

--- a/openspec/changes/add-org-webhooks/tasks.md
+++ b/openspec/changes/add-org-webhooks/tasks.md
@@ -1,35 +1,42 @@
 ## 1. YAML Parsing and Resolution
 
-- [ ] 1.1 Add `org_webhook_names` local that reads `org_webhooks` list from `local.common_config` (default `[]`)
-- [ ] 1.2 Add `resolved_org_webhooks` local that looks up each name in `local.webhooks_config`, normalizes types, and resolves `env:VAR_NAME` secrets via `var.webhook_secrets`
-- [ ] 1.3 Guard org webhook resolution with `local.is_organization` (empty map for personal accounts)
-- [ ] 1.4 Verify: `terraform plan` with org webhooks defined produces expected resource count; plan with no `org_webhooks` key produces zero resources
+- [x] 1.1 Add `org_webhook_names` local that reads `org_webhooks` list from
+  `local.common_config` (default `[]`)
+- [x] 1.2 Add `resolved_org_webhooks` local that looks up each name in `local.webhooks_config`,
+  normalizes types, and resolves `env:VAR_NAME` secrets via `var.webhook_secrets`
+- [x] 1.3 Guard org webhook resolution with `local.is_organization` (empty map for personal
+  accounts)
+- [x] 1.4 Verify: `terraform plan` with org webhooks defined produces expected resource count;
+  plan with no `org_webhooks` key produces zero resources
 
 ## 2. Terraform Resource
 
-- [ ] 2.1 Add `github_organization_webhook.this` resource in `main.tf` with `for_each = local.resolved_org_webhooks`
-- [ ] 2.2 Map configuration block: url, content_type, secret (sensitive), insecure_ssl
-- [ ] 2.3 Map events list and active flag
-- [ ] 2.4 Verify: `terraform plan` shows correct create/update/destroy for org webhook changes
+- [x] 2.1 Add `github_organization_webhook.this` resource in `main.tf` with
+  `for_each = local.resolved_org_webhooks`
+- [x] 2.2 Map configuration block: url, content_type, secret (sensitive), insecure_ssl
+- [x] 2.3 Map events list and active flag
+- [x] 2.4 Verify: `terraform plan` shows correct create/update/destroy for org webhook changes
 
 ## 3. Outputs
 
-- [ ] 3.1 Add `org_webhooks` output in `outputs.tf` (map of webhook names to URLs)
-- [ ] 3.2 Verify: output is empty map when no org webhooks configured
+- [x] 3.1 Add `org_webhooks` output in `outputs.tf` (map of webhook names to URLs)
+- [x] 3.2 Verify: output is empty map when no org webhooks configured
 
 ## 4. Config Template
 
-- [ ] 4.1 Add `org_webhooks` example (commented out) to `config/config.yml` template
-- [ ] 4.2 Add example org webhook definition to `config/webhook/` template directory
+- [x] 4.1 Add `org_webhooks` example (commented out) to `config/config.yml` template
+- [x] 4.2 Add example org webhook definition to `config/webhook/` template directory
 
 ## 5. Validation
 
-- [ ] 5.1 Update `scripts/validate-config.py` to validate `org_webhooks` references resolve to defined webhooks
-- [ ] 5.2 Update `scripts/validate-config.py` to warn when `org_webhooks` is set but `is_organization` is false
-- [ ] 5.3 Verify: validation script catches undefined org webhook references
+- [x] 5.1 Update `scripts/validate-config.py` to validate `org_webhooks` references resolve to
+  defined webhooks
+- [x] 5.2 Update `scripts/validate-config.py` to warn when `org_webhooks` is set but
+  `is_organization` is false
+- [x] 5.3 Verify: validation script catches undefined org webhook references
 
 ## 6. Documentation
 
-- [ ] 6.1 Update AGENTS.md with org webhook configuration guidance
-- [ ] 6.2 Add org webhooks section to consumer example comments
-- [ ] 6.3 Document that org webhooks fire for ALL repos in the org
+- [x] 6.1 Update AGENTS.md with org webhook configuration guidance
+- [x] 6.2 Add org webhooks section to consumer example comments
+- [x] 6.3 Document that org webhooks fire for ALL repos in the org

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,6 +78,13 @@ output "organization_settings_warnings" {
 # All three outputs share the same shape for consistency.
 
 
+output "org_webhooks" {
+  description = "Map of organization webhook names to their URLs (empty when no org webhooks configured)"
+  value = {
+    for name, webhook in github_organization_webhook.this : name => webhook.url
+  }
+}
+
 # Output warning when duplicate keys are detected across config files
 # Duplicates cause shallow merge - the entire definition from the later file wins
 output "duplicate_key_warnings" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -80,6 +80,7 @@ output "organization_settings_warnings" {
 
 output "org_webhooks" {
   description = "Map of organization webhook names to their URLs (empty when no org webhooks configured)"
+  sensitive   = true
   value = {
     for name, webhook in github_organization_webhook.this : name => webhook.url
   }

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -22,6 +22,7 @@ REPOSITORY_DIR = CONFIG_DIR / "repository"
 RULESET_DIR = CONFIG_DIR / "ruleset"
 TEAM_DIR = CONFIG_DIR / "team"
 MEMBERSHIP_DIR = CONFIG_DIR / "membership"
+WEBHOOK_DIR = CONFIG_DIR / "webhook"
 
 VALID_VISIBILITIES = ["public", "private", "internal"]
 VALID_MEMBERSHIP_ROLES = ["member", "admin"]
@@ -121,7 +122,12 @@ def split_rulesets_by_scope(rulesets: dict) -> tuple[dict, dict]:
 
 def validate_config(config: dict) -> list[str]:
     """Validate config.yml."""
+
+
+def validate_config(config: dict, webhooks: dict) -> tuple[list[str], list[str]]:
+    """Validate config.yml. Returns (errors, warnings)."""
     errors = []
+    warnings = []
 
     if "organization" not in config:
         errors.append("config.yml: Missing required field 'organization'")
@@ -130,7 +136,22 @@ def validate_config(config: dict) -> list[str]:
     if subscription not in VALID_SUBSCRIPTIONS:
         errors.append(f"config.yml: Invalid subscription '{subscription}'")
 
-    return errors
+    # Validate org_webhooks references
+    is_organization = config.get("is_organization", True)
+    org_webhooks = config.get("org_webhooks", [])
+    if org_webhooks:
+        if not is_organization:
+            warnings.append(
+                "config.yml: 'org_webhooks' is set but 'is_organization' is false — "
+                "org webhooks will not be created for personal accounts"
+            )
+        for name in org_webhooks:
+            if name not in webhooks:
+                errors.append(
+                    f"config.yml: org_webhooks references '{name}' which is not defined in config/webhook/"
+                )
+
+    return errors, warnings
 
 
 def validate_settings(config: dict) -> tuple[list[str], list[str]]:
@@ -708,8 +729,6 @@ def main():
             teams = load_team_directory(TEAM_DIR)
         else:
             teams = {}
-        # Membership directory is optional
-        members = load_yaml_directory(MEMBERSHIP_DIR) if MEMBERSHIP_DIR.exists() else {}
         # Membership directory is optional (load_yaml_directory handles missing dir)
         try:
             members = load_yaml_directory(MEMBERSHIP_DIR)
@@ -718,6 +737,8 @@ def main():
                 f"Invalid membership configuration: each YAML file in {MEMBERSHIP_DIR} "
                 "must contain a top-level mapping (username: role), not a list or scalar."
             ) from e
+        # Load webhook definitions (optional directory)
+        webhooks = load_yaml_directory(WEBHOOK_DIR) if WEBHOOK_DIR.exists() else {}
     except ValueError as e:
         print(f"ERROR: {e}")
         sys.exit(1)
@@ -727,7 +748,9 @@ def main():
     org_ruleset_names = set(org_rulesets.keys())
 
     # Validate each config type
-    all_errors.extend(validate_config(config))
+    config_errors, config_warnings = validate_config(config, webhooks)
+    all_errors.extend(config_errors)
+    all_warnings.extend(config_warnings)
     settings_errors, settings_warnings = validate_settings(config)
     all_errors.extend(settings_errors)
     all_warnings.extend(settings_warnings)
@@ -801,6 +824,9 @@ def main():
         print(f"  - Repositories: {len(repos)}")
         print(f"  - Rulesets: {len(rulesets)}")
         print(f"  - Teams: {len(flat_teams)}")
+        org_webhooks = config.get("org_webhooks", [])
+        if org_webhooks:
+            print(f"  - Org webhooks: {len(org_webhooks)} ({', '.join(org_webhooks)})")
 
         # Print warnings (non-fatal)
         all_warnings = team_warnings

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -140,16 +140,29 @@ def validate_config(config: dict, webhooks: dict) -> tuple[list[str], list[str]]
     is_organization = config.get("is_organization", True)
     org_webhooks = config.get("org_webhooks", [])
     if org_webhooks:
-        if not is_organization:
-            warnings.append(
-                "config.yml: 'org_webhooks' is set but 'is_organization' is false — "
-                "org webhooks will not be created for personal accounts"
+        if not isinstance(org_webhooks, list) or not all(
+            isinstance(n, str) for n in org_webhooks
+        ):
+            errors.append(
+                "config.yml: 'org_webhooks' must be a list of webhook name strings, "
+                f"got {type(org_webhooks).__name__}"
             )
-        for name in org_webhooks:
-            if name not in webhooks:
-                errors.append(
-                    f"config.yml: org_webhooks references '{name}' which is not defined in config/webhook/"
+        else:
+            if not is_organization:
+                warnings.append(
+                    "config.yml: 'org_webhooks' is set but 'is_organization' is false — "
+                    "org webhooks will not be created for personal accounts"
                 )
+            for name in org_webhooks:
+                if name not in webhooks:
+                    errors.append(
+                        f"config.yml: org_webhooks references '{name}' which is not defined in config/webhook/"
+                    )
+                elif not webhooks[name].get("events"):
+                    errors.append(
+                        f"config/webhook/{name}: 'events' must define at least one event "
+                        "(required by the GitHub provider)"
+                    )
 
     return errors, warnings
 

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -361,8 +361,9 @@ locals {
     var.membership_management_enabled && local.is_organization
   ) ? local.membership_config : {}
   # Organization-level webhook names
-  # Reads the org_webhooks list from config.yml; empty for personal accounts
-  org_webhook_names = local.is_organization ? tolist(lookup(local.common_config, "org_webhooks", [])) : []
+  # Reads the org_webhooks list from config.yml; empty for personal accounts.
+  # try() guards against org_webhooks being null or a non-list type in YAML.
+  org_webhook_names = local.is_organization ? try(tolist(lookup(local.common_config, "org_webhooks", [])), []) : []
 
   # Organization webhook invalid references (for check block)
   # Collects any org_webhook names not defined in config/webhook/
@@ -371,12 +372,19 @@ locals {
     if lookup(local.webhooks_config, name, null) == null
   ]
 
+  # Org webhook definitions that are missing the required url field
+  invalid_org_webhook_urls = [
+    for name in local.org_webhook_names : name
+    if lookup(local.webhooks_config, name, null) != null &&
+    try(tostring(lookup(local.webhooks_config, name, {}).url), null) == null
+  ]
+
   # Resolve org webhook definitions: look up each name in webhooks_config,
   # normalize types, and apply env:VAR_NAME secret resolution.
   # Only populated for organizations; empty map for personal accounts.
   resolved_org_webhooks_raw = local.is_organization ? {
     for name in local.org_webhook_names : name => {
-      url          = tostring(lookup(local.webhooks_config, name, { url = null }).url)
+      url          = try(tostring(lookup(local.webhooks_config, name, {}).url), null)
       content_type = tostring(lookup(lookup(local.webhooks_config, name, {}), "content_type", "json"))
       secret       = try(tostring(lookup(local.webhooks_config, name, {}).secret), null)
       events       = tolist(lookup(lookup(local.webhooks_config, name, {}), "events", []))
@@ -1073,6 +1081,17 @@ check "org_webhook_references" {
       ${join("\n      ", [for name in local.invalid_org_webhook_refs : "- '${name}' is not defined in config/webhook/"])}
 
       Available webhooks: ${join(", ", keys(local.webhooks_config))}
+    EOT
+  }
+}
+
+# Validate that all referenced org webhooks have a non-null url field
+check "org_webhook_urls" {
+  assert {
+    condition     = length(local.invalid_org_webhook_urls) == 0
+    error_message = <<-EOT
+      Org webhooks missing required 'url' field:
+      ${join("\n      ", [for name in local.invalid_org_webhook_urls : "- '${name}' in config/webhook/ has no url"])}
     EOT
   }
 }

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -360,6 +360,47 @@ locals {
   effective_membership = (
     var.membership_management_enabled && local.is_organization
   ) ? local.membership_config : {}
+  # Organization-level webhook names
+  # Reads the org_webhooks list from config.yml; empty for personal accounts
+  org_webhook_names = local.is_organization ? tolist(lookup(local.common_config, "org_webhooks", [])) : []
+
+  # Organization webhook invalid references (for check block)
+  # Collects any org_webhook names not defined in config/webhook/
+  invalid_org_webhook_refs = [
+    for name in local.org_webhook_names : name
+    if lookup(local.webhooks_config, name, null) == null
+  ]
+
+  # Resolve org webhook definitions: look up each name in webhooks_config,
+  # normalize types, and apply env:VAR_NAME secret resolution.
+  # Only populated for organizations; empty map for personal accounts.
+  resolved_org_webhooks_raw = local.is_organization ? {
+    for name in local.org_webhook_names : name => {
+      url          = tostring(lookup(local.webhooks_config, name, { url = null }).url)
+      content_type = tostring(lookup(lookup(local.webhooks_config, name, {}), "content_type", "json"))
+      secret       = try(tostring(lookup(local.webhooks_config, name, {}).secret), null)
+      events       = tolist(lookup(lookup(local.webhooks_config, name, {}), "events", []))
+      active       = tobool(lookup(lookup(local.webhooks_config, name, {}), "active", true))
+      insecure_ssl = tobool(lookup(lookup(local.webhooks_config, name, {}), "insecure_ssl", false))
+    }
+    if lookup(local.webhooks_config, name, null) != null
+  } : {}
+
+  # Resolve env:VAR_NAME secrets for org webhooks (same pattern as repo webhooks)
+  resolved_org_webhooks = {
+    for name, webhook in local.resolved_org_webhooks_raw : name => {
+      url          = webhook.url
+      content_type = webhook.content_type
+      secret = (
+        webhook.secret != null && can(regex("^env:", webhook.secret)) ?
+        lookup(var.webhook_secrets, substr(webhook.secret, 4, -1), null) :
+        webhook.secret
+      )
+      events       = webhook.events
+      active       = webhook.active
+      insecure_ssl = webhook.insecure_ssl
+    }
+  }
 
   # 1.1 Organization-level settings configuration
   # Parses optional `settings:` block from config.yml.
@@ -1020,6 +1061,19 @@ check "valid_partitions" {
   assert {
     condition     = length(local.invalid_partition_names) == 0
     error_message = "Invalid partition name(s): ${join(", ", local.invalid_partition_names)}. Available partitions: ${join(", ", sort(tolist(local.repository_partition_dirs)))}. Check config/repository/ for valid subdirectory names."
+  }
+}
+
+# Validate that all org_webhook references are defined in config/webhook/
+check "org_webhook_references" {
+  assert {
+    condition     = length(local.invalid_org_webhook_refs) == 0
+    error_message = <<-EOT
+      Invalid org_webhook references found in config.yml:
+      ${join("\n      ", [for name in local.invalid_org_webhook_refs : "- '${name}' is not defined in config/webhook/"])}
+
+      Available webhooks: ${join(", ", keys(local.webhooks_config))}
+    EOT
   }
 }
 


### PR DESCRIPTION
## Summary

Add `github_organization_webhook` resource support so org-level webhooks can be managed via YAML config. Org webhooks fire for events across **all** repositories in the organization — unlike repository webhooks which are scoped to a single repo.

Closes #30

## What changed

- **`yaml-config.tf`**: new `org_webhook_names`, `resolved_org_webhooks_raw`, and `resolved_org_webhooks` locals; `check "org_webhook_references"` block to catch undefined references at plan time
- **`main.tf`**: new `github_organization_webhook.this` resource (`for_each = local.resolved_org_webhooks`); guarded by `is_organization` via the resolved map being empty for personal accounts
- **`outputs.tf`**: new `org_webhooks` output — map of webhook name → URL
- **`config/config.yml`**: commented-out `org_webhooks` example
- **`config/webhook/examples.yml`**: org-specific webhook examples (`audit-logger`, `ci-notifier`) with org-relevant events (`repository`, `member`, `team`, `organization`)
- **`scripts/validate-config.py`**: validates `org_webhooks` references resolve to defined webhooks; warns when `org_webhooks` is set but `is_organization: false`
- **`AGENTS.md`**: new "Configuring organization webhooks" section
- **`examples/consumer/main.tf`**: org webhook usage comments

## Design notes

- Reuses the existing `config/webhook/` definition format and `env:VAR_NAME` secret resolution pattern — no new variables needed
- No subscription tier gating (`github_organization_webhook` works on all tiers)
- Undefined references caught by a `check` block (same pattern as template references)
- Personal account guard: `is_organization: false` → `resolved_org_webhooks` is empty map → zero resources created