### PR TITLE
feat(security): add org-level security manager team designation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,32 @@ org_webhooks:
 - Secrets follow the same `env:VAR_NAME` pattern as repo webhooks; pass via `webhook_secrets` variable
 - Org webhooks work on all GitHub subscription tiers (no tier gating)
 
+### Managing security managers
+
+Security managers are GitHub teams with read access to security alerts and advisories across all
+repositories. Requires Team or Enterprise subscription.
+
+1. Edit `config/config.yml` and add a `security` section:
+
+   ```yaml
+   security:
+     security_manager_teams:
+       - security-team
+   ```
+
+1. Ensure `subscription` is set to `team` or `enterprise` in `config/config.yml`
+1. Teams must already exist — this module does not create teams
+1. Run `terraform plan` to preview, then `terraform apply`
+
+**Subscription tier limitations:**
+
+Security manager roles require `team` or `enterprise` subscription. On `free` or `pro` plans,
+the resources are silently skipped. The validation script will warn if teams are configured on
+an unsupported tier.
+
+**Note:** Uses `github_organization_role_team` with dynamic role ID lookup (the deprecated
+`github_organization_security_manager` resource is not used).
+
 ### Importing existing repositories
 
 ```bash

--- a/config/config.yml
+++ b/config/config.yml
@@ -109,3 +109,14 @@ defaults:
 #   # Whether Actions can approve pull request reviews
 #   # Secure default: false
 #   can_approve_pull_request_reviews: false
+
+# Organization-level security configuration (optional)
+# Requires Team or Enterprise subscription tier
+# Uncomment and configure to designate teams as security managers
+# Security managers receive read access to security alerts across all repositories
+#
+# security:
+#   # List of team slugs to assign the security_manager organization role
+#   # Teams must already exist before being assigned as security managers
+#   security_manager_teams:
+#     - security-team

--- a/examples/consumer/config/config.yml
+++ b/examples/consumer/config/config.yml
@@ -18,3 +18,10 @@ subscription: free
 #   allowed_actions: all            # all, local_only, selected
 #   default_workflow_permissions: read
 #   can_approve_pull_request_reviews: false
+
+# Optional: organization-level security manager teams (requires team/enterprise subscription)
+# Teams listed here receive read access to security alerts across all repositories.
+# Teams must already exist before being assigned as security managers.
+# security:
+#   security_manager_teams:
+#     - security-team

--- a/main.tf
+++ b/main.tf
@@ -364,12 +364,26 @@ data "github_organization_roles" "this" {
 }
 
 locals {
-  # Extract the security_manager role ID from the data source
-  # Used by github_organization_role_team resources below
-  security_manager_role_id = length(local.security_manager_teams) > 0 ? one([
-    for role in data.github_organization_roles.this[0].roles :
-    role.role_id if role.name == "security_manager"
-  ]) : null
+  # Extract the security_manager role ID from the data source.
+  # try() prevents a cryptic one() error when the role is absent or duplicated;
+  # the check block below surfaces a clear diagnostic instead.
+  security_manager_role_id = length(local.security_manager_teams) > 0 ? try(
+    one([
+      for role in data.github_organization_roles.this[0].roles :
+      role.role_id if role.name == "security_manager"
+    ]),
+    null
+  ) : null
+}
+
+# Validate that the security_manager role actually exists in the organization.
+# Produces a clear error when the role is missing (e.g., wrong subscription tier)
+# rather than a cryptic one() or null reference failure.
+check "security_manager_role_exists" {
+  assert {
+    condition     = length(local.security_manager_teams) == 0 || local.security_manager_role_id != null
+    error_message = "The 'security_manager' role was not found in this GitHub organization. Ensure the organization has a Team or Enterprise subscription and that the role exists."
+  }
 }
 
 # Assign the security_manager organization role to each configured team

--- a/main.tf
+++ b/main.tf
@@ -356,3 +356,27 @@ module "teams_level_2" {
 
   review_request_delegation = each.value.review_request_delegation
 }
+
+# Look up organization roles to resolve the security_manager role ID dynamically
+# Only instantiated when security manager teams are configured and supported
+data "github_organization_roles" "this" {
+  count = length(local.security_manager_teams) > 0 ? 1 : 0
+}
+
+locals {
+  # Extract the security_manager role ID from the data source
+  # Used by github_organization_role_team resources below
+  security_manager_role_id = length(local.security_manager_teams) > 0 ? one([
+    for role in data.github_organization_roles.this[0].roles :
+    role.role_id if role.name == "security_manager"
+  ]) : null
+}
+
+# Assign the security_manager organization role to each configured team
+# One resource per team slug — requires Team or Enterprise subscription
+resource "github_organization_role_team" "security_managers" {
+  for_each = local.security_manager_teams
+
+  role_id   = local.security_manager_role_id
+  team_slug = each.value
+}

--- a/openspec/changes/add-security-management/tasks.md
+++ b/openspec/changes/add-security-management/tasks.md
@@ -1,38 +1,38 @@
 ## 1. YAML Configuration Schema
 
-- [ ] 1.1 Add commented-out `security` section to `config/config.yml` with `security_manager_teams` example
-- [ ] 1.2 Update AGENTS.md to document the new security configuration section
+- [x] 1.1 Add commented-out `security` section to `config/config.yml` with `security_manager_teams` example
+- [x] 1.2 Update AGENTS.md to document the new security configuration section
 
 ## 2. Terraform Config Parsing
 
-- [ ] 2.1 Add `security_config` local in `yaml-config.tf` to extract `security` from `common_config` (defaulting to null when absent)
-- [ ] 2.2 Add `security_managers_supported` local boolean gated on `is_organization` and subscription tier (`team`/`enterprise`)
-- [ ] 2.3 Add `security_manager_teams` local that resolves the team slug list (empty when unsupported or unconfigured)
+- [x] 2.1 Add `security_config` local in `yaml-config.tf` to extract `security` from `common_config` (defaulting to null when absent)
+- [x] 2.2 Add `security_managers_supported` local boolean gated on `is_organization` and subscription tier (`team`/`enterprise`)
+- [x] 2.3 Add `security_manager_teams` local that resolves the team slug list (empty when unsupported or unconfigured)
 
 ## 3. Terraform Resources
 
-- [ ] 3.1 Add `data.github_organization_roles` data source in `main.tf` with conditional count (only when security managers are configured and supported)
-- [ ] 3.2 Add local to extract `security_manager` role ID from the data source
-- [ ] 3.3 Add `github_organization_role_team` resource with `for_each` over `security_manager_teams` using the resolved role ID
+- [x] 3.1 Add `data.github_organization_roles` data source in `main.tf` with conditional count (only when security managers are configured and supported)
+- [x] 3.2 Add local to extract `security_manager` role ID from the data source
+- [x] 3.3 Add `github_organization_role_team` resource with `for_each` over `security_manager_teams` using the resolved role ID
 
 ## 4. Outputs
 
-- [ ] 4.1 Add output for security manager team assignments (list of team slugs assigned the security manager role)
+- [x] 4.1 Add output for security manager team assignments (list of team slugs assigned the security manager role)
 
 ## 5. Validation Script
 
-- [ ] 5.1 Update `scripts/validate-config.py` to validate `security` section schema (optional section, `security_manager_teams` must be list of strings)
-- [ ] 5.2 Add subscription tier warning when security manager teams are configured on `free` or `pro` tier
+- [x] 5.1 Update `scripts/validate-config.py` to validate `security` section schema (optional section, `security_manager_teams` must be list of strings)
+- [x] 5.2 Add subscription tier warning when security manager teams are configured on `free` or `pro` tier
 
 ## 6. Documentation and Examples
 
-- [ ] 6.1 Update `config/config.yml` template comments with security configuration example
-- [ ] 6.2 Update `examples/consumer/` if needed to show security configuration usage
+- [x] 6.1 Update `config/config.yml` template comments with security configuration example
+- [x] 6.2 Update `examples/consumer/` if needed to show security configuration usage
 
 ## 7. Verification
 
-- [ ] 7.1 Run `terraform fmt` and `terraform validate` on all changed files
-- [ ] 7.2 Run `pre-commit run --all-files` to check formatting and linting
-- [ ] 7.3 Run `terraform plan` with security manager teams configured to verify resource creation
-- [ ] 7.4 Run `terraform plan` without security section to verify no resources are created
-- [ ] 7.5 Run validation script against config with and without security section
+- [x] 7.1 Run `terraform fmt` and `terraform validate` on all changed files
+- [x] 7.2 Run `pre-commit run --all-files` to check formatting and linting
+- [x] 7.3 Run `terraform plan` with security manager teams configured to verify resource creation
+- [x] 7.4 Run `terraform plan` without security section to verify no resources are created
+- [x] 7.5 Run validation script against config with and without security section

--- a/outputs.tf
+++ b/outputs.tf
@@ -77,6 +77,12 @@ output "organization_settings_warnings" {
 # skipping; organization_settings_warnings covers enterprise-only settings skipping.
 # All three outputs share the same shape for consistency.
 
+# Output the list of teams assigned the security manager role
+output "security_manager_teams" {
+  description = "List of team slugs assigned the security_manager organization role"
+  value       = tolist(local.security_manager_teams)
+}
+
 
 output "org_webhooks" {
   description = "Map of organization webhook names to their URLs (empty when no org webhooks configured)"

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,9 +78,10 @@ output "organization_settings_warnings" {
 # All three outputs share the same shape for consistency.
 
 # Output the list of teams assigned the security manager role
+# sort() ensures deterministic ordering regardless of set iteration order
 output "security_manager_teams" {
   description = "List of team slugs assigned the security_manager organization role"
-  value       = tolist(local.security_manager_teams)
+  value       = sort(tolist(local.security_manager_teams))
 }
 
 

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -120,10 +120,6 @@ def split_rulesets_by_scope(rulesets: dict) -> tuple[dict, dict]:
     return repo_rulesets, org_rulesets
 
 
-def validate_config(config: dict) -> list[str]:
-    """Validate config.yml."""
-
-
 def validate_config(config: dict, webhooks: dict) -> tuple[list[str], list[str]]:
     """Validate config.yml. Returns (errors, warnings)."""
     errors = []
@@ -162,6 +158,37 @@ def validate_config(config: dict, webhooks: dict) -> tuple[list[str], list[str]]
                     errors.append(
                         f"config/webhook/{name}: 'events' must define at least one event "
                         "(required by the GitHub provider)"
+                    )
+
+    # Validate optional security section
+    security = config.get("security")
+    if security is not None:
+        if not isinstance(security, dict):
+            errors.append("config.yml: 'security' must be a mapping")
+        else:
+            teams = security.get("security_manager_teams")
+            if teams is not None:
+                if not isinstance(teams, list):
+                    errors.append(
+                        "config.yml: 'security.security_manager_teams' must be a list"
+                    )
+                else:
+                    for i, team in enumerate(teams):
+                        if not isinstance(team, str):
+                            errors.append(
+                                f"config.yml: 'security.security_manager_teams[{i}]' must be a string, got {type(team).__name__}"
+                            )
+                # Warn when teams are configured on an unsupported tier
+                if (
+                    not errors
+                    and isinstance(teams, list)
+                    and len(teams) > 0
+                    and subscription in ["free", "pro"]
+                ):
+                    warnings.append(
+                        f"config.yml: security_manager_teams configured but subscription '{subscription}' "
+                        "does not support security manager roles (requires 'team' or 'enterprise') — "
+                        "resources will be skipped"
                     )
 
     return errors, warnings
@@ -817,6 +844,12 @@ def main():
             print(f"Strict mode: {len(all_warnings)} warning(s) treated as error(s)")
             sys.exit(1)
 
+    # Report warnings (non-fatal)
+    if all_warnings:
+        for warning in all_warnings:
+            print(f"WARNING: {warning}")
+        print()
+
     # Report results
     if all_errors:
         print("Validation FAILED:")
@@ -840,6 +873,18 @@ def main():
         org_webhooks = config.get("org_webhooks", [])
         if org_webhooks:
             print(f"  - Org webhooks: {len(org_webhooks)} ({', '.join(org_webhooks)})")
+
+        if members:
+            print(f"  - Members: {len(members)}")
+
+        security = config.get("security", {})
+        sec_teams = (
+            security.get("security_manager_teams", [])
+            if isinstance(security, dict)
+            else []
+        )
+        if sec_teams:
+            print(f"  - Security manager teams: {len(sec_teams)}")
 
         # Print warnings (non-fatal)
         all_warnings = team_warnings

--- a/scripts/validate-config.py
+++ b/scripts/validate-config.py
@@ -166,9 +166,24 @@ def validate_config(config: dict, webhooks: dict) -> tuple[list[str], list[str]]
         if not isinstance(security, dict):
             errors.append("config.yml: 'security' must be a mapping")
         else:
-            teams = security.get("security_manager_teams")
-            if teams is not None:
-                if not isinstance(teams, list):
+            # Warn on unknown keys — the section is narrow enough to make typos detectable cheaply
+            known_security_keys = {"security_manager_teams"}
+            unknown_keys = set(security.keys()) - known_security_keys
+            if unknown_keys:
+                warnings.append(
+                    f"config.yml: Unknown key(s) in 'security': {', '.join(sorted(unknown_keys))}"
+                )
+
+            # Use key presence check rather than .get() to distinguish an absent key
+            # from one explicitly set to null — the latter is invalid for Terraform (toset(null) errors).
+            if "security_manager_teams" in security:
+                teams = security["security_manager_teams"]
+                if teams is None:
+                    errors.append(
+                        "config.yml: 'security.security_manager_teams' must be a list, not null "
+                        "(use [] for an empty list)"
+                    )
+                elif not isinstance(teams, list):
                     errors.append(
                         "config.yml: 'security.security_manager_teams' must be a list"
                     )
@@ -178,18 +193,14 @@ def validate_config(config: dict, webhooks: dict) -> tuple[list[str], list[str]]
                             errors.append(
                                 f"config.yml: 'security.security_manager_teams[{i}]' must be a string, got {type(team).__name__}"
                             )
-                # Warn when teams are configured on an unsupported tier
-                if (
-                    not errors
-                    and isinstance(teams, list)
-                    and len(teams) > 0
-                    and subscription in ["free", "pro"]
-                ):
-                    warnings.append(
-                        f"config.yml: security_manager_teams configured but subscription '{subscription}' "
-                        "does not support security manager roles (requires 'team' or 'enterprise') — "
-                        "resources will be skipped"
-                    )
+                    # Tier warning is informational — emit regardless of other unrelated errors
+                    # so users always see it on re-run after fixing separate issues.
+                    if len(teams) > 0 and subscription in ["free", "pro"]:
+                        warnings.append(
+                            f"config.yml: security_manager_teams configured but subscription '{subscription}' "
+                            "does not support security manager roles (requires 'team' or 'enterprise') — "
+                            "resources will be skipped"
+                        )
 
     return errors, warnings
 

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -460,6 +460,10 @@ locals {
     contains(keys(local.org_settings_effective), "billing_email")
   ) ? local.org_settings_effective : null
 
+  # Organization-level security configuration
+  # Defaults to null if not specified (no security manager resources created)
+  security_config = lookup(local.common_config, "security", null)
+
   # Subscription tier feature availability
   # - free: Rulesets only work on public repositories
   # - pro: Rulesets work on public and private repositories
@@ -477,6 +481,18 @@ locals {
   # Track which org rulesets are skipped due to subscription tier
   # (only meaningful in organization mode; personal accounts simply never have org rulesets)
   skipped_org_ruleset_names = local.is_organization && local.org_rulesets_require_paid ? keys(local.org_rulesets_config) : []
+
+  # Whether security manager team designation is supported
+  # Requires: organization account + team or enterprise subscription
+  security_managers_supported = local.is_organization && contains(["team", "enterprise"], local.subscription)
+
+  # Resolved list of team slugs to assign the security_manager role
+  # Empty when feature is unsupported or no teams are configured
+  security_manager_teams = (
+    local.security_managers_supported && local.security_config != null
+    ? toset(lookup(local.security_config, "security_manager_teams", []))
+    : toset([])
+  )
 
   # Merge multiple config groups for each repository
   # Groups are applied sequentially: later groups override single values, lists are merged

--- a/yaml-config.tf
+++ b/yaml-config.tf
@@ -462,7 +462,8 @@ locals {
 
   # Organization-level security configuration
   # Defaults to null if not specified (no security manager resources created)
-  security_config = lookup(local.common_config, "security", null)
+  # Only applicable for organizations, not personal accounts (mirrors org_actions_config pattern)
+  security_config = local.is_organization ? lookup(local.common_config, "security", null) : null
 
   # Subscription tier feature availability
   # - free: Rulesets only work on public repositories
@@ -488,9 +489,11 @@ locals {
 
   # Resolved list of team slugs to assign the security_manager role
   # Empty when feature is unsupported or no teams are configured
+  # coalesce(..., []) guards against security_manager_teams being explicitly set to null in YAML
+  # (lookup() propagates null rather than substituting the default in that case)
   security_manager_teams = (
     local.security_managers_supported && local.security_config != null
-    ? toset(lookup(local.security_config, "security_manager_teams", []))
+    ? toset(coalesce(lookup(local.security_config, "security_manager_teams", []), []))
     : toset([])
   )
 


### PR DESCRIPTION
## Summary

- Adds optional \`security.security_manager_teams\` to \`config/config.yml\` for designating GitHub teams as org-level security managers
- Implements \`github_organization_role_team\` resource with dynamic role ID lookup via \`github_organization_roles\` data source
- Gates the feature on \`is_organization = true\` + \`team\`/\`enterprise\` subscription tier (silently skips on free/pro, matching the existing rulesets pattern)
- Adds schema validation and tier warning to \`scripts/validate-config.py\`

## What Changed

| File | Change |
|------|--------|
| \`config/config.yml\` | Add commented-out \`security\` section example |
| \`yaml-config.tf\` | Add \`security_config\`, \`security_managers_supported\`, \`security_manager_teams\` locals |
| \`main.tf\` | Add \`data.github_organization_roles\`, role ID local, \`github_organization_role_team\` resource |
| \`outputs.tf\` | Add \`security_manager_teams\` output |
| \`scripts/validate-config.py\` | Validate security section schema; warn on unsupported tier |
| \`examples/consumer/config/config.yml\` | Add commented security example |
| \`AGENTS.md\` | Document security manager configuration |

## Behaviour

- **No security section** → no resources created, \`security_manager_teams = []\`
- **free/pro + teams configured** → resources silently skipped (validation script warns)
- **team/enterprise + teams configured** → one \`github_organization_role_team\` per slug
- **personal account (\`is_organization: false\`)** → always skipped

## Notes

Uses the non-deprecated \`github_organization_role_team\` resource (not \`github_organization_security_manager\`). Teams must pre-exist — this module does not create teams.

Closes #34