### PR TITLE
fix(repository): migrate from deprecated vulnerability_alerts argument

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -27,7 +27,6 @@ resource "github_repository" "this" {
   allow_update_branch         = var.allow_update_branch
   delete_branch_on_merge      = var.delete_branch_on_merge
   web_commit_signoff_required = var.web_commit_signoff_required
-  vulnerability_alerts        = var.vulnerability_alerts
 
   topics = var.topics
 
@@ -39,6 +38,12 @@ resource "github_repository" "this" {
     prevent_destroy = false
     ignore_changes  = [auto_init]
   }
+}
+
+# Manage Dependabot vulnerability alerts via the dedicated resource.
+resource "github_repository_vulnerability_alerts" "this" {
+  repository = github_repository.this.name
+  enabled    = var.vulnerability_alerts
 }
 
 # Manage team access to the repository


### PR DESCRIPTION
## What

Replace the deprecated `vulnerability_alerts` argument on `github_repository` in
`modules/repository/main.tf` with a separate `github_repository_vulnerability_alerts`
resource. The module's public input variable (`var.vulnerability_alerts`) is unchanged,
so consumers do not need to update their YAML or Terraform code.

## Why

The `integrations/github` provider (`~> 6.0`) has deprecated the inline
`vulnerability_alerts` argument. Every `terraform plan` against this module currently
emits a warning per repository:

```
Warning: Argument is deprecated
  with module.<...>.module.repositories[<repo>].github_repository.this,
  on modules/repository/main.tf line 30, in resource "github_repository" "this":
  30:   vulnerability_alerts        = var.vulnerability_alerts
Use the github_repository_vulnerability_alerts resource instead. This field will
be removed in a future version.
```

The provider documentation directs users to the dedicated
`github_repository_vulnerability_alerts` resource. See the provider docs:
https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_vulnerability_alerts

## How

- Removed `vulnerability_alerts = var.vulnerability_alerts` from
  `resource "github_repository" "this"`.
- Added a new top-level resource in the same module file:
  ```hcl
  resource "github_repository_vulnerability_alerts" "this" {
    repository = github_repository.this.name
    enabled    = var.vulnerability_alerts
  }
  ```
- `var.vulnerability_alerts` (still `bool`, default `true`) is preserved unchanged so
  the module's public API stays stable.
- `lifecycle.ignore_changes` is left as `[auto_init]` -- no other ignores needed; the
  provider no longer reports drift for `vulnerability_alerts` on the
  `github_repository` resource once the argument is unset.

## Testing

- `terraform fmt -recursive` -- no changes.
- `terraform validate` (in `modules/repository/`) -- `Success! The configuration is valid.`
  No deprecation warning anymore.
- `terraform validate` (root) -- success.
- `pre-commit run --files modules/repository/main.tf` -- all relevant hooks pass
  (terraform_fmt, terraform_validate, terraform_validate_with_tflint, detect-secrets,
  end-of-file-fixer, trailing-whitespace, check-merge-conflict, etc).

## State migration note for existing consumers

After upgrading to a release containing this change, existing users will see one new
resource per managed repository on their next `terraform plan`:

```
# module.<...>.module.repositories[<repo>].github_repository_vulnerability_alerts.this will be created
```

This is safe and idempotent: the new resource simply re-asserts the Dependabot
vulnerability-alert state (which the inline argument was already maintaining).
There is no action required from consumers; running `terraform apply` is enough.
Power users who want a perfectly clean plan can `terraform import` each new
resource using the repository name, but it is not necessary.