### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>gjed/renovate-config:default"]
+}


### PR DESCRIPTION
Adds `.renovaterc.json` to onboard this repository to the shared [gjed/renovate-config](https://github.com/gjed/renovate-config) preset.

Renovate will auto-merge minor and patch updates, and open PRs for major updates.